### PR TITLE
* Fix Player::getCorpse

### DIFF
--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -101,8 +101,7 @@ TalkActionResult_t Spells::playerSaySpell(const std::shared_ptr<Player> &player,
 	if (instantSpell->playerCastInstant(player, param)) {
 		if (!player->checkSpellNameInsteadOfWords()) {
 			words = instantSpell->getWords();
-		}
-		else {
+		} else {
 			words = instantSpell->getName();
 		}
 

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -123,13 +123,13 @@ public:
 
 	virtual CreatureType_t getType() const = 0;
 
-    bool isPlayer() const {
-        return getType() == CreatureType_t::CREATURETYPE_PLAYER;
-    }
+	bool isPlayer() const {
+		return getType() == CreatureType_t::CREATURETYPE_PLAYER;
+	}
 
-    bool isMonster() const {
-        return getType() == CreatureType_t::CREATURETYPE_MONSTER;
-    }
+	bool isMonster() const {
+		return getType() == CreatureType_t::CREATURETYPE_MONSTER;
+	}
 
 	virtual void setID() = 0;
 	void setRemoved() {

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -123,6 +123,14 @@ public:
 
 	virtual CreatureType_t getType() const = 0;
 
+    bool isPlayer() const {
+        return getType() == CreatureType_t::CREATURETYPE_PLAYER;
+    }
+
+    bool isMonster() const {
+        return getType() == CreatureType_t::CREATURETYPE_MONSTER;
+    }
+
 	virtual void setID() = 0;
 	void setRemoved() {
 		isInternalRemoved = true;


### PR DESCRIPTION
# Description

Fixed getCorpse behavior in different situations.

## Behaviour
### **Actual**
09:50 You see a dead human (Vol:10).
You recognize Knight. He was killed by Paladin and a brachiodemon, a brachiodemon, an infernal phantom, an infernal demon, an infernal demon, an infernal phantom, an infernal demon, a brachiodemon, an infernal demon, an infernal phantom and a brachiodemon.

### **Expected**
Different situations:
by player
10:06 You see a dead human (Vol:10).
You recognize Knight. He was killed by Paladin.

by player and monsters
10:09 You see a dead human (Vol:10).
You recognize Knight. He was killed by Paladin and a brachiodemon.


by player and they summons
10:16 You see a dead human (Vol:10).
You recognize Knight. He was killed by Master Chain and a fire elemental summoned by Master Chain.
