### PR TITLE
* Fixed sending damage higher then monster health

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7499,7 +7499,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 		int32_t adjustedDamage = realDamage;
 		if (target) {
 			if (realDamage > targetHealth) {
-				 adjustedDamage = targetHealth > 0 ? targetHealth : realDamage;
+				adjustedDamage = targetHealth > 0 ? targetHealth : realDamage;
 			}
 		}
 
@@ -7512,7 +7512,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 			targetPlayer,
 			message,
 			spectators.data(),
-			adjustedDamage //realDamage
+			adjustedDamage // realDamage
 		);
 
 		if (attackerPlayer) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7496,6 +7496,13 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 
 		addCreatureHealth(spectators.data(), target);
 
+		int32_t adjustedDamage = realDamage;
+		if (target) {
+			if (realDamage > targetHealth) {
+				 adjustedDamage = targetHealth > 0 ? targetHealth : realDamage;
+			}
+		}
+
 		sendDamageMessageAndEffects(
 			attacker,
 			target,
@@ -7505,7 +7512,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 			targetPlayer,
 			message,
 			spectators.data(),
-			realDamage
+			adjustedDamage //realDamage
 		);
 
 		if (attackerPlayer) {


### PR DESCRIPTION
# Description

Fix damage sending 

## Behaviour
### **Actual**
A rat loses 332 hitpoints due to your attack.

### **Expected**
A rat loses 20 hitpoints due to your attack.

### Fixes  https://github.com/opentibiabr/canary/issues/3197

## Type of change
