### PR TITLE
* Fix mana drain not displayed in Input Analyzer

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7500,7 +7500,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 			spectators.find<Player>(targetPos, true);
 		}
 
-		addCreatureHealth(spectators.data(), target);	
+		addCreatureHealth(spectators.data(), target);
 
 		sendDamageMessageAndEffects(
 			attacker,
@@ -7930,7 +7930,7 @@ bool Game::combatChangeMana(const std::shared_ptr<Creature> &attacker, const std
 		if (attacker) {
 			cause = attacker->getName();
 		}
-	
+
 		if (targetPlayer) {
 			targetPlayer->updateInputAnalyzer(damage.primary.type, manaLoss, cause);
 		}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7466,7 +7466,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 		}
 
 		auto targetHealth = target->getHealth();
-		realDamage = damage.primary.value + damage.secondary.value;
+		realDamage = std::min<int32_t>(targetHealth, damage.primary.value + damage.secondary.value);
 		if (realDamage == 0) {
 			return true;
 		} else if (realDamage >= targetHealth) {
@@ -7500,14 +7500,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 			spectators.find<Player>(targetPos, true);
 		}
 
-		addCreatureHealth(spectators.data(), target);
-
-		int32_t adjustedDamage = realDamage;
-		if (target) {
-			if (realDamage > targetHealth) {
-				adjustedDamage = targetHealth > 0 ? targetHealth : realDamage;
-			}
-		}
+		addCreatureHealth(spectators.data(), target);	
 
 		sendDamageMessageAndEffects(
 			attacker,
@@ -7518,7 +7511,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 			targetPlayer,
 			message,
 			spectators.data(),
-			adjustedDamage // realDamage
+			realDamage
 		);
 
 		if (attackerPlayer) {
@@ -7933,6 +7926,14 @@ bool Game::combatChangeMana(const std::shared_ptr<Creature> &attacker, const std
 		}
 
 		target->drainMana(attacker, manaLoss);
+		std::string cause = "(other)";
+		if (attacker) {
+			cause = attacker->getName();
+		}
+	
+		if (targetPlayer) {
+			targetPlayer->updateInputAnalyzer(damage.primary.type, manaLoss, cause);
+		}
 
 		std::stringstream ss;
 
@@ -7964,7 +7965,7 @@ bool Game::combatChangeMana(const std::shared_ptr<Creature> &attacker, const std
 				} else if (targetPlayer == attackerPlayer) {
 					ss << " due to your own attack.";
 				} else {
-					ss << " mana due to an attack by " << attacker->getNameDescription() << '.';
+					ss << " due to an attack by " << attacker->getNameDescription() << '.';
 				}
 				message.type = MESSAGE_DAMAGE_RECEIVED;
 				message.text = ss.str();


### PR DESCRIPTION
# Description

Fixed mana drian not displayed in Input Damage Analzyer

## Behaviour
### **Actual**

Input Analyzer does not display mana drain

### **Expected**

Input Analyzer display mana drain
  ![mana](https://github.com/user-attachments/assets/f1d1940d-2428-42e3-9778-76150c3d6030)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Every monster that drain players mana can be tested

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works

