### PR TITLE
[FEATURE] Name Change to save old player Names

### DIFF
--- a/data/migrations/51.lua
+++ b/data/migrations/51.lua
@@ -1,0 +1,16 @@
+function onUpdateDatabase()
+	logger.info("Updating database to version 51 (Player Old Names)")
+
+	db.query([[ 
+		CREATE TABLE `player_oldnames` (
+			`id` int(11) NOT NULL AUTO_INCREMENT,
+			`player_id` int(11) NOT NULL,
+			`former_name` varchar(255) NOT NULL DEFAULT '',
+			`name` varchar(255) NOT NULL,
+			`old_name` varchar(255) NOT NULL,
+			`date` int(11) NOT NULL,
+			PRIMARY KEY (`id`),
+			INDEX `player_id_index` (`player_id`)
+		)
+	]])
+end

--- a/markdowns/CHANGELOG.md
+++ b/markdowns/CHANGELOG.md
@@ -10,10 +10,14 @@
 - Added new flags: `CanMoveFromFar`, `HasFullLight`, `AllowIdle`, `CanWearAllMounts`, and `NotGainUnjustified`. ([Tryller](https://github.com/jprzimba))
 - Added Vibrancy imbuement. ([pennaor](https://github.com/pennaor))
 - Added Soul Pit arena/animus mastery/soul core. ([FelipePaluco](https://github.com/FelipePaluco))
+- Cyclopedia House Auction system. ([murilo09](https://github.com/murilo09))
+- Updated name change functionality to save old player names in a database table called `player_oldnames`. ([Tryller](https://github.com/jprzimba))
 
 ## Added files
 
 - data/migrations/49.lua
+- data/migrations/50.lua
+- data/migrations/51.lua
 - data-global/lib/others/soulpit.lua
 - data-global/startup/tables/tile.lua
 - data-global/npc/myzzi.lua
@@ -72,7 +76,6 @@
 - Add new configurable featurees in `config.lua`:  `chainSystemVipOnly`, `fieldOwnershipDuration`, `bedsOnlyPremium`, `loginProtectionPeriod`, `chainSystemModifyMagic`, `logPlayersStatements`. ([Tryller](https://github.com/jprzimba))
 - Added a new commands for players: `!randomoutfit`, `!spellwords`. ([Tryller](https://github.com/jprzimba))
 - Moved emote spells to `kv` instead of `storage`. ([Tryller](https://github.com/jprzimba))
-- Cyclopedia House Auction system. ([murilo09](https://github.com/murilo09))
 - Updated npcs and spells from 13.40 updates. ([murilo09](https://github.com/murilo09))
 - Added a Rook system with configurations in `config.lua`. ([Tryller](https://github.com/jprzimba))
 - Added a new group `game tester` with flag `isgametester` in `groups.xml` and a new player flag `PlayerFlag_IsGameTester`. ([Tryller](https://github.com/jprzimba))

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -859,7 +859,7 @@ bool IOLoginDataSave::changeName(const std::shared_ptr<Player> &player, const st
 	}
 
 	query << "INSERT INTO `player_oldnames` (`player_id`, `former_name`, `name`, `old_name`, `date`) VALUES ("
-		<< player->getGUID() << ", " << db.escapeString(formerName) << ", " << db.escapeString(newName) << ", " << db.escapeString(oldName) << ", " << now << ")";
+		  << player->getGUID() << ", " << db.escapeString(formerName) << ", " << db.escapeString(newName) << ", " << db.escapeString(oldName) << ", " << now << ")";
 
 	if (!db.executeQuery(query.str())) {
 		return false;

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -840,7 +840,7 @@ bool IOLoginDataSave::savePlayerStatement(const std::shared_ptr<Player> &player,
 	return true;
 }
 
-bool IOLoginDataSave::changeName(const std::shared_ptr<Player> &player, const std::string &newName, const std::string &oldName) {
+bool IOLoginDataSave::savePlayerNamesAndChangeName(const std::shared_ptr<Player> &player, const std::string &newName, const std::string &oldName) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayerStatement] - Player nullptr: {}", __FUNCTION__);
 		return false;

--- a/src/io/functions/iologindata_save_player.hpp
+++ b/src/io/functions/iologindata_save_player.hpp
@@ -39,6 +39,7 @@ public:
 	static bool savePlayerBosstiary(const std::shared_ptr<Player> &player);
 	static bool savePlayerStorage(const std::shared_ptr<Player> &player);
 	static bool savePlayerStatement(const std::shared_ptr<Player> &player, const std::string &receiver, uint16_t channelId, const std::string &text, uint32_t &statementId);
+	static bool changeName(const std::shared_ptr<Player> &player, const std::string &newName, const std::string &oldName);
 
 protected:
 	using ItemBlockList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;

--- a/src/io/functions/iologindata_save_player.hpp
+++ b/src/io/functions/iologindata_save_player.hpp
@@ -39,7 +39,7 @@ public:
 	static bool savePlayerBosstiary(const std::shared_ptr<Player> &player);
 	static bool savePlayerStorage(const std::shared_ptr<Player> &player);
 	static bool savePlayerStatement(const std::shared_ptr<Player> &player, const std::string &receiver, uint16_t channelId, const std::string &text, uint32_t &statementId);
-	static bool changeName(const std::shared_ptr<Player> &player, const std::string &newName, const std::string &oldName);
+	static bool savePlayerNamesAndChangeName(const std::shared_ptr<Player> &player, const std::string &newName, const std::string &oldName);
 
 protected:
 	using ItemBlockList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -4217,7 +4217,7 @@ int PlayerFunctions::luaPlayerChangeName(lua_State* L) {
 	player->kv()->remove("namelock");
 	const auto newName = Lua::getString(L, 2);
 	const auto oldName = player->getName();
-	IOLoginDataSave::changeName(player, newName, oldName);
+	IOLoginDataSave::savePlayerNamesAndChangeName(player, newName, oldName);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -36,6 +36,7 @@
 #include "game/scheduling/save_manager.hpp"
 #include "io/iobestiary.hpp"
 #include "io/iologindata.hpp"
+#include "io/functions/iologindata_save_player.hpp"
 #include "io/ioprey.hpp"
 #include "items/containers/depot/depotchest.hpp"
 #include "items/containers/depot/depotlocker.hpp"
@@ -4212,13 +4213,11 @@ int PlayerFunctions::luaPlayerChangeName(lua_State* L) {
 		Lua::pushBoolean(L, false);
 		return 0;
 	}
-	if (player->isOnline()) {
-		player->removePlayer(true, true);
-	}
+
 	player->kv()->remove("namelock");
 	const auto newName = Lua::getString(L, 2);
-	player->setName(newName);
-	g_saveManager().savePlayer(player);
+	const auto oldName = player->getName();
+	IOLoginDataSave::changeName(player, newName, oldName);
 	return 1;
 }
 


### PR DESCRIPTION
# Description

This feature implements a name change system that saves old player names in a new database table, `player_oldnames`.

## Behaviour
### **Actual**

Dont save player old names

### **Expected**

Save old player names to database

## Type of change

  - [x] New feature (non-breaking change which adds functionality)
  - [x] This change requires a documentation update

## How Has This Been Tested

Tested with store name changer

**Test Configuration**:

  - Server Version: 4.1.3
  - Client: 14.05
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
