### PR TITLE
* Fix imbuement empty slot

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -99,7 +99,17 @@ std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0
 	return newItem;
 }
 
+bool Item::hasImbuementAttribute(const std::string &attributeSlot) const {
+	// attributeSlot = ITEM_IMBUEMENT_SLOT + slot id
+	return getCustomAttribute(attributeSlot) != nullptr;
+}
+
 bool Item::getImbuementInfo(uint8_t slot, ImbuementInfo* imbuementInfo) const {
+	std::string attributeSlot = std::to_string(ITEM_IMBUEMENT_SLOT + slot);
+	if (!hasImbuementAttribute(attributeSlot)) {
+		return false;
+	}
+
 	const CustomAttribute* attribute = getCustomAttribute(std::to_string(ITEM_IMBUEMENT_SLOT + slot));
 	const auto info = attribute ? attribute->getAttribute<uint32_t>() : 0;
 	imbuementInfo->imbuement = g_imbuements().getImbuement(info & 0xFF);

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -692,6 +692,7 @@ public:
 		return false;
 	}
 	bool hasImbuementCategoryId(uint16_t categoryId) const;
+	bool hasImbuementAttribute(const std::string &attributeSlot) const;
 	bool hasImbuements() const {
 		for (uint8_t slotid = 0; slotid < getImbuementSlot(); slotid++) {
 			ImbuementInfo imbuementInfo;


### PR DESCRIPTION
This enhances the management of imbuement slots by verifying whether a slot is empty before retrieving imbuement details.  
Previously, the `getImbuementInfo` function would return an invalid imbuement even for empty slots. Now, it ensures that only valid imbuements are processed.