### PR TITLE
Boss Lever and Trap Fix

### DIFF
--- a/data/scripts/movements/trap.lua
+++ b/data/scripts/movements/trap.lua
@@ -3,7 +3,7 @@ local traps = {
 	[2148] = { damage = { -50, -100 } },
 	[3482] = { transformTo = 3481, damage = { -15, -30 }, ignorePlayer = (Game.getWorldType() == WORLD_TYPE_NO_PVP) },
 	[3944] = { transformTo = 3945, damage = { -15, -30 }, type = COMBAT_EARTHDAMAGE },
-	[12368] = { ignorePlayer = true },
+	[12368] = { ignorePlayer = true, damage = { 0, 0 }, },
 }
 
 local trap = MoveEvent()


### PR DESCRIPTION
Added condition to check if it's player properly in Boss lever to avoid crash when a summon or npc steps on tile for boss teleport.

Added damage condtion in trap to avoid error flood when something steps in and damage is nill.