### PR TITLE
[fix] wrong elemental damage weapons calculation 

### DIFF
--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -255,8 +255,7 @@ void Weapon::internalUseWeapon(const std::shared_ptr<Player> &player, const std:
 		LuaVariant var;
 		var.type = VARIANT_NUMBER;
 		var.number = target->getID();
-		executeUseWeapon(player, var);
-		g_logger().debug("Weapon::internalUseWeapon - Lua callback executed.");
+		executeUseWeapon(player, var);			
 	} else {
 		CombatDamage damage;
 		const WeaponType_t weaponType = item->getWeaponType();
@@ -270,7 +269,21 @@ void Weapon::internalUseWeapon(const std::shared_ptr<Player> &player, const std:
 		damage.primary.value = (getWeaponDamage(player, target, item) * damageModifier) / 100;
 		damage.secondary.type = getElementType();
 
-		// Cleave damage
+		const int32_t totalDamage = (getWeaponDamage(player, target, item) * damageModifier) / 100;
+		const int32_t physicalAttack = item->getAttack();
+		const int32_t elementalAttack = getElementDamageValue();
+		const int32_t combinedAttack = physicalAttack + elementalAttack;
+		if (elementalAttack > 0) {
+			float physicalPercentage = static_cast<float>(physicalAttack) / combinedAttack;
+			float elementalPercentage = static_cast<float>(elementalAttack) / combinedAttack;
+			damage.primary.value = static_cast<int32_t>(totalDamage * physicalPercentage);
+			damage.secondary.value = static_cast<int32_t>(totalDamage * elementalPercentage);
+		} else {
+			damage.primary.value = totalDamage;
+			damage.secondary.value = 0;
+		}
+
+		// Apply cleave adjustments if applicable
 		uint16_t damagePercent = 100;
 		if (cleavePercent != 0) {
 			damage.extension = true;
@@ -279,24 +292,17 @@ void Weapon::internalUseWeapon(const std::shared_ptr<Player> &player, const std:
 				damage.exString += ", ";
 			}
 			damage.exString += "cleave damage";
+			damage.primary.value = (damage.primary.value * damagePercent) / 100;
+			damage.secondary.value = (damage.secondary.value * damagePercent) / 100;
 		}
 
-		if (damage.secondary.type == COMBAT_NONE) {
-			damage.primary.value = (getWeaponDamage(player, target, item) * damageModifier / 100) * damagePercent / 100;
-			damage.secondary.value = 0;
-		} else {
-			damage.primary.value = (getWeaponDamage(player, target, item) * damageModifier / 100) * damagePercent / 100;
-			damage.secondary.value = (getElementDamage(player, target, item) * damageModifier / 100) * damagePercent / 100;
-		}
-
+		// Handle chain system
 		if (player->checkChainSystem() && params.chainCallback) {
 			m_combat->doCombatChain(player, target, params.aggressive);
 			g_logger().debug("Weapon::internalUseWeapon - Chain callback executed.");
 		} else {
 			Combat::doCombatHealth(player, target, damage, params);
 		}
-
-		g_logger().debug("Weapon::internalUseWeapon - cpp callback executed.");
 	}
 
 	onUsedWeapon(player, item, target->getTile());
@@ -623,13 +629,15 @@ int16_t WeaponMelee::getElementDamageValue() const {
 }
 
 int32_t WeaponMelee::getWeaponDamage(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &, const std::shared_ptr<Item> &item, bool maxDamage /*= false*/) const {
-	using namespace std;
 	const int32_t attackSkill = player->getWeaponSkill(item);
-	const int32_t attackValue = std::max<int32_t>(0, item->getAttack());
+	const int32_t physicalAttack = std::max<int32_t>(0, item->getAttack());
+	const int32_t elementalAttack = getElementDamageValue();
+	const int32_t combinedAttack = physicalAttack + elementalAttack;
+
 	const float attackFactor = player->getAttackFactor();
 	const uint32_t level = player->getLevel();
 
-	const int32_t maxValue = static_cast<int32_t>(Weapons::getMaxWeaponDamage(level, attackSkill, attackValue, attackFactor, true) * player->getVocation()->meleeDamageMultiplier);
+	const auto maxValue = static_cast<int32_t>(Weapons::getMaxWeaponDamage(level, attackSkill, combinedAttack, attackFactor, true) * player->getVocation()->meleeDamageMultiplier);
 
 	const int32_t minValue = level / 5;
 
@@ -637,7 +645,7 @@ int32_t WeaponMelee::getWeaponDamage(const std::shared_ptr<Player> &player, cons
 		return -maxValue;
 	}
 
-	return -normal_random(minValue, (maxValue * static_cast<int32_t>(player->getVocation()->meleeDamageMultiplier)));
+	return -normal_random(minValue, maxValue);
 }
 
 WeaponDistance::WeaponDistance() {

--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -255,7 +255,7 @@ void Weapon::internalUseWeapon(const std::shared_ptr<Player> &player, const std:
 		LuaVariant var;
 		var.type = VARIANT_NUMBER;
 		var.number = target->getID();
-		executeUseWeapon(player, var);			
+		executeUseWeapon(player, var);
 	} else {
 		CombatDamage damage;
 		const WeaponType_t weaponType = item->getWeaponType();


### PR DESCRIPTION
This update resolves an issue with the elemental weapon damage calculation. Previously, the damage for elemental weapons was duplicated instead of being correctly divided into 60% elemental and 40% physical. This led to incorrect damage values and made certain weapons overly powerful.

The revised logic ensures that the total damage remains balanced, properly distributing it between elemental and physical components while correctly applying target resistances and weaknesses.