### PR TITLE
[fix] map issues with traps

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -76400,6 +76400,15 @@ Granted by TibiaGoals.com"/>
 		<attribute key="decayTo" value="0"/>
 		<attribute key="duration" value="5"/>
 	</item>
+	<item id="44529" name="slits">
+		<attribute key="duration" value="10"/>
+		<attribute key="decayTo" value="44530"/>
+	</item>
+	<item id="44530" name="blades">
+		<attribute key="primarytype" value="fields"/>
+		<attribute key="duration" value="10"/>
+		<attribute key="decayTo" value="44529"/>
+	</item>
 	<item id="44602" article="a" name="lesser guardian gem" plural="lesser guardian gems">
 		<attribute key="description" value="Shines with the strength of knights" />
 		<attribute key="loottype" value="valuable" />

--- a/data/scripts/movements/trap.lua
+++ b/data/scripts/movements/trap.lua
@@ -4,6 +4,7 @@ local traps = {
 	[3482] = { transformTo = 3481, damage = { -15, -30 }, ignorePlayer = (Game.getWorldType() == WORLDTYPE_OPTIONAL) },
 	[3944] = { transformTo = 3945, damage = { -15, -30 }, type = COMBAT_EARTHDAMAGE },
 	[12368] = { ignorePlayer = true },
+	[44530] = { transformTo = 44529, damage = { -50, -100 } },
 }
 
 local trap = MoveEvent()

--- a/data/scripts/movements/trap.lua
+++ b/data/scripts/movements/trap.lua
@@ -1,10 +1,10 @@
 local traps = {
 	[2145] = { transformTo = 2146, damage = { -50, -100 } },
-	[2148] = { damage = { -50, -100 } },
+	[2147] = { transformTo = 2148, damage = { -50, -100 } },
 	[3482] = { transformTo = 3481, damage = { -15, -30 }, ignorePlayer = (Game.getWorldType() == WORLDTYPE_OPTIONAL) },
 	[3944] = { transformTo = 3945, damage = { -15, -30 }, type = COMBAT_EARTHDAMAGE },
 	[12368] = { ignorePlayer = true },
-	[44530] = { transformTo = 44529, damage = { -50, -100 } },
+	[44529] = { transformTo = 44530, damage = { -50, -100 } },
 }
 
 local trap = MoveEvent()
@@ -66,7 +66,7 @@ function trap.onStepOut(creature, item, position, fromPosition)
 end
 
 trap:type("stepout")
-trap:id(2146, 3945)
+trap:id(2146, 2148, 3945, 44530)
 trap:register()
 
 trap = MoveEvent()


### PR DESCRIPTION
NOTE: Update your map to the latest world.7z in the world folder.  
Alternatively, edit your map by replacing all IDs: change 2148 to 2147 and 44530 to 44529.  