### PR TITLE
[fix] spawns npc by time

### DIFF
--- a/data-global/lib/quests/soul_war.lua
+++ b/data-global/lib/quests/soul_war.lua
@@ -1233,7 +1233,7 @@ function Monster:tryTeleportToPlayer(sayMessage)
 	for i, spectator in ipairs(spectators) do
 		if spectator:isPlayer() then
 			local player = spectator:getPlayer()
-            if player:getTaintNameByNumber(1) and player:getSoulWarZoneMonster() ~= nil then
+			if player:getTaintNameByNumber(1) and player:getSoulWarZoneMonster() ~= nil then
 				local distance = self:getPosition():getDistance(player:getPosition())
 				if distance > maxDistance then
 					maxDistance = distance

--- a/data-global/scripts/world_changes/spawns_npc_by_time.lua
+++ b/data-global/scripts/world_changes/spawns_npc_by_time.lua
@@ -1,28 +1,114 @@
+local activeNpcRefs = {}
+
 local npcSpawns = {
-	{ name = "Ghostly Wolf", spawnPeriod = LIGHT_STATE_SUNSET, despawnPeriod = LIGHT_STATE_SUNRISE, position = { x = 33332, y = 32052, z = 7 } },
-	{ name = "Talila", spawnPeriod = LIGHT_STATE_SUNSET, despawnPeriod = LIGHT_STATE_SUNRISE, position = { x = 33504, y = 32222, z = 7 } },
-	{ name = "Valindara", spawnPeriod = LIGHT_STATE_SUNRISE, despawnPeriod = LIGHT_STATE_SUNSET, position = { x = 33504, y = 32222, z = 7 } },
+	{
+		name = "Ghostly Wolf",
+		spawnPeriod = LIGHT_STATE_SUNSET,
+		despawnPeriod = LIGHT_STATE_SUNRISE,
+		position = Position(33332, 32052, 7),
+	},
+	{
+		name = "Talila",
+		spawnPeriod = LIGHT_STATE_SUNSET,
+		despawnPeriod = LIGHT_STATE_SUNRISE,
+		position = Position(33504, 32222, 7),
+	},
+	{
+		name = "Valindara",
+		spawnPeriod = LIGHT_STATE_SUNRISE,
+		despawnPeriod = LIGHT_STATE_SUNSET,
+		position = Position(33504, 32222, 7),
+	},
 }
 
 local spawnsNpcByTime = GlobalEvent("SpawnsNpcByTime")
 
 function spawnsNpcByTime.onPeriodChange(period)
-	for _, npcSpawn in ipairs(npcSpawns) do
-		if npcSpawn.spawnPeriod == period then
-			local spawnNpc = Game.createNpc(npcSpawn.name, npcSpawn.position)
-			if spawnNpc then
-				spawnNpc:setMasterPos(npcSpawn.position)
-				spawnNpc:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-			end
-		elseif npcSpawn.despawnPeriod == period then
-			local despawnNpc = Npc(npcSpawn.name)
-			if despawnNpc then
-				despawnNpc:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-				despawnNpc:remove()
-			end
+	local npcsToRemove = {}
+	local npcsToAdd = {}
+	for i, npcData in ipairs(npcSpawns) do
+		if npcData.despawnPeriod == period and activeNpcRefs[i] then
+			table.insert(npcsToRemove, {
+				index = i,
+				data = npcData,
+			})
+		elseif npcData.spawnPeriod == period and not activeNpcRefs[i] then
+			table.insert(npcsToAdd, {
+				index = i,
+				data = npcData,
+			})
 		end
 	end
+	for _, entry in ipairs(npcsToRemove) do
+		local npc = Creature(activeNpcRefs[entry.index])
+		if npc and npc:isNpc() then
+			npc:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+			npc:remove()
+		end
+		activeNpcRefs[entry.index] = nil
+	end
+	if #npcsToAdd > 0 then
+		addEvent(function()
+			for _, entry in ipairs(npcsToAdd) do
+				local npc = Game.createNpc(entry.data.name, entry.data.position)
+				if npc then
+					npc:setMasterPos(entry.data.position)
+					npc:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+					activeNpcRefs[entry.index] = npc:getId()
+				else
+					logger.error("NpcByTime: Failed to spawn:", entry.data.name)
+				end
+			end
+		end, 5000)
+	end
+
 	return true
 end
 
 spawnsNpcByTime:register()
+
+local spawnsNpcBySpawn = GlobalEvent("SpawnsNpcBySpawn")
+
+function spawnsNpcBySpawn.onStartup()
+	local currentPeriod = LIGHT_STATE_SUNRISE
+
+	local mode = getTibiaTimerDayOrNight()
+	if mode == "night" then
+		currentPeriod = LIGHT_STATE_SUNSET
+	else
+		currentPeriod = LIGHT_STATE_SUNRISE
+	end
+
+	local npcsToAdd = {}
+
+	for i, npcData in ipairs(npcSpawns) do
+		if npcData.spawnPeriod == currentPeriod then
+			table.insert(npcsToAdd, {
+				index = i,
+				data = npcData,
+			})
+		end
+	end
+
+	if #npcsToAdd > 0 then
+		addEvent(function()
+			for _, entry in ipairs(npcsToAdd) do
+				local npc = Game.createNpc(entry.data.name, entry.data.position)
+				if npc then
+					npc:setMasterPos(entry.data.position)
+					npc:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+					activeNpcRefs[entry.index] = npc:getId()
+					logger.info("NpcByTime: " .. entry.data.name .. " spawned successfully.")
+				else
+					logger.error("NpcByTime: Failed to spawn:", entry.data.name)
+				end
+			end
+		end, 5000)
+	else
+		logger.info("NpcByTime: No NPCs to spawn in the current period.")
+	end
+
+	return true
+end
+
+spawnsNpcBySpawn:register()

--- a/data-global/world/world-npc.xml
+++ b/data-global/world/world-npc.xml
@@ -1611,9 +1611,6 @@
 	<npc centerx="32271" centery="32052" centerz="7" radius="1">
 		<npc name="Valentina" x="0" y="0" z="7" spawntime="60" />
 	</npc>
-	<npc centerx="33332" centery="32052" centerz="7" radius="5">
-		<npc name="Ghostly Wolf" x="0" y="0" z="7" spawntime="60" />
-	</npc>
 	<npc centerx="32253" centery="32055" centerz="7" radius="1">
 		<npc name="Tokel" x="0" y="0" z="7" spawntime="60" />
 	</npc>


### PR DESCRIPTION
This fix addresses the issue where NPCs were being duplicated due to incorrect handling of their addition and removal. Now, there is no longer a need for the NPCs to be defined in the XML file, as they are created dynamically through the script when the server starts.

thanks to @LeoTKBR