### PR TITLE
improve: creature zone change

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -753,8 +753,15 @@ void Creature::changeHealth(int32_t healthChange, bool sendHealthChange /* = tru
 	if (sendHealthChange && oldHealth != health) {
 		g_game().addCreatureHealth(static_self_cast<Creature>());
 	}
+
 	if (health <= 0) {
-		g_dispatcher().addEvent([creatureId = getID()] { g_game().executeDeath(creatureId); }, "Game::executeDeath");
+		g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
+			if (const auto &creature = self.lock()) {
+				if (!creature->isRemoved()) {
+					creature->onDeath();
+				}
+			}
+		}, "Creature::onDeath");
 	}
 }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -10766,12 +10766,12 @@ ReturnValue Game::beforeCreatureZoneChange(const std::shared_ptr<Creature> &crea
 	}
 
 	// fromZones - toZones = zones that creature left
-	const auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
 		return toZones.find(z) == toZones.end();
 	});
 
 	// toZones - fromZones = zones that creature entered
-	const auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
+	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
 		return fromZones.find(z) == fromZones.end();
 	});
 
@@ -10801,12 +10801,12 @@ void Game::afterCreatureZoneChange(const std::shared_ptr<Creature> &creature, co
 	}
 
 	// fromZones - toZones = zones that creature left
-	const auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
 		return toZones.find(z) == toZones.end();
 	});
 
 	// toZones - fromZones = zones that creature entered
-	const auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
+	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
 		return fromZones.find(z) == fromZones.end();
 	});
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1276,15 +1276,6 @@ bool Game::removeCreature(const std::shared_ptr<Creature> &creature, bool isLogo
 	return true;
 }
 
-void Game::executeDeath(uint32_t creatureId) {
-	metrics::method_latency measure(__METRICS_METHOD_NAME__);
-	std::shared_ptr<Creature> creature = getCreatureByID(creatureId);
-	if (creature && !creature->isRemoved()) {
-		afterCreatureZoneChange(creature, creature->getZones(), {});
-		creature->onDeath();
-	}
-}
-
 void Game::playerTeleport(uint32_t playerId, const Position &newPosition) {
 	metrics::method_latency measure(__METRICS_METHOD_NAME__);
 	const auto &player = getPlayerByID(playerId);
@@ -10769,29 +10760,20 @@ void Game::setTransferPlayerHouseItems(uint32_t houseId, uint32_t playerId) {
 	transferHouseItemsToPlayer[houseId] = playerId;
 }
 
-template <typename T>
-std::vector<T> setDifference(const std::unordered_set<T> &setA, const std::unordered_set<T> &setB) {
-	std::vector<T> setResult;
-	setResult.reserve(setA.size());
-
-	for (const auto &elem : setA) {
-		if (!setB.contains(elem)) {
-			setResult.emplace_back(elem);
-		}
-	}
-
-	return setResult;
-}
-
 ReturnValue Game::beforeCreatureZoneChange(const std::shared_ptr<Creature> &creature, const std::unordered_set<std::shared_ptr<Zone>> &fromZones, const std::unordered_set<std::shared_ptr<Zone>> &toZones, bool force /* = false*/) const {
 	if (!creature) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
 	// fromZones - toZones = zones that creature left
-	const auto &zonesLeaving = setDifference(fromZones, toZones);
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
+		return toZones.find(z) == toZones.end();
+	});
+
 	// toZones - fromZones = zones that creature entered
-	const auto &zonesEntering = setDifference(toZones, fromZones);
+	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
+		return fromZones.find(z) == fromZones.end();
+	});
 
 	if (zonesLeaving.empty() && zonesEntering.empty()) {
 		return RETURNVALUE_NOERROR;
@@ -10813,28 +10795,28 @@ ReturnValue Game::beforeCreatureZoneChange(const std::shared_ptr<Creature> &crea
 	return RETURNVALUE_NOERROR;
 }
 
-void Game::afterCreatureZoneChange(const std::shared_ptr<Creature> &creatures, const std::unordered_set<std::shared_ptr<Zone>> &fromZones, const std::unordered_set<std::shared_ptr<Zone>> &toZones) const {
-	auto creature = creatures;
+void Game::afterCreatureZoneChange(const std::shared_ptr<Creature> &creature, const std::unordered_set<std::shared_ptr<Zone>> &fromZones, const std::unordered_set<std::shared_ptr<Zone>> &toZones) const {
 	if (!creature) {
 		return;
 	}
 
 	// fromZones - toZones = zones that creature left
-	const auto &zonesLeaving = setDifference(fromZones, toZones);
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
+		return toZones.find(z) == toZones.end();
+	});
+
 	// toZones - fromZones = zones that creature entered
-	const auto &zonesEntering = setDifference(toZones, fromZones);
+	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
+		return fromZones.find(z) == fromZones.end();
+	});
 
 	for (const auto &zone : zonesLeaving) {
 		zone->creatureRemoved(creature);
-	}
-	for (const auto &zone : zonesEntering) {
-		zone->creatureAdded(creature);
-	}
-
-	for (const auto &zone : zonesLeaving) {
 		g_callbacks().executeCallback(EventCallback_t::zoneAfterCreatureLeave, &EventCallback::zoneAfterCreatureLeave, zone, creature);
 	}
+
 	for (const auto &zone : zonesEntering) {
+		zone->creatureAdded(creature);
 		g_callbacks().executeCallback(EventCallback_t::zoneAfterCreatureEnter, &EventCallback::zoneAfterCreatureEnter, zone, creature);
 	}
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -10766,12 +10766,12 @@ ReturnValue Game::beforeCreatureZoneChange(const std::shared_ptr<Creature> &crea
 	}
 
 	// fromZones - toZones = zones that creature left
-	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
+	const auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
 		return toZones.find(z) == toZones.end();
 	});
 
 	// toZones - fromZones = zones that creature entered
-	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
+	const auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
 		return fromZones.find(z) == fromZones.end();
 	});
 
@@ -10801,12 +10801,12 @@ void Game::afterCreatureZoneChange(const std::shared_ptr<Creature> &creature, co
 	}
 
 	// fromZones - toZones = zones that creature left
-	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
+	const auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
 		return toZones.find(z) == toZones.end();
 	});
 
 	// toZones - fromZones = zones that creature entered
-	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
+	const auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
 		return fromZones.find(z) == fromZones.end();
 	});
 

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -186,7 +186,6 @@ public:
 	bool placeCreature(const std::shared_ptr<Creature> &creature, const Position &pos, bool extendedPos = false, bool force = false);
 
 	bool removeCreature(const std::shared_ptr<Creature> &creature, bool isLogout = true);
-	void executeDeath(uint32_t creatureId);
 
 	void addCreatureCheck(const std::shared_ptr<Creature> &creature);
 	static void removeCreatureCheck(const std::shared_ptr<Creature> &creature);


### PR DESCRIPTION
[NÃO TESTADO]

- Removendo o `Game::afterCreatureZoneChange` que está sendo chamado em `Creature::changeHealth` pois ele já está sendo chamado em `Game::removeCreature`.

- Removendo `Game::executeDeath` e `setDifference` que não estão sendo usados mais.

- Usando `std::views::filter` no lugar de` setDifference` (o correto seria fazer um teste de performance entre os dois).

- Removendo a cópia desnecessária de creature em `Game::afterCreatureZoneChange`

- Removendo loop duplicado para zones

-----------------
[UNTESTED]

- Removing Game::afterCreatureZoneChange, which is being called in Creature::changeHealth, since it is already being called in Game::removeCreature.

- Removing Game::executeDeath and setDifference, which are no longer being used.

- Using std::views::filter instead of setDifference (ideally, a performance test between the two should be conducted).

- Removing the unnecessary copy of creature in Game::afterCreatureZoneChange.

- Removing the duplicated loop for zones.