### PR TITLE
fix: ensure imbuement is applied before setting stats to player

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2399,12 +2399,16 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 		return;
 	}
 
+	if (!item->addImbuement(slot, imbuement->getID(), baseImbuement->duration)) {
+		g_logger().error("[Player::onApplyImbuement] - An error occurred while player with name {} trying to apply imbuement in a different item than the opened in the window, probably trying to abuse bug", this->getName());
+		return;
+	}
+
 	// Update imbuement stats item if the item is equipped
 	if (item->getParent() == getPlayer()) {
 		addItemImbuementStats(imbuement);
 	}
 
-	item->addImbuement(slot, imbuement->getID(), baseImbuement->duration);
 	updateImbuementTrackerStats();
 	openImbuementWindow(item);
 }

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -125,29 +125,31 @@ void Item::setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
 void Item::addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
 	const auto &player = getHoldingPlayer();
 	if (!player) {
-		return;
+		return false;
 	}
 
 	// Get imbuement by the id
 	const Imbuement* imbuement = g_imbuements().getImbuement(imbuementId);
 	if (!imbuement) {
-		return;
+		return false;
 	}
 
 	// Get category imbuement for acess category id
 	const CategoryImbuement* categoryImbuement = g_imbuements().getCategoryByID(imbuement->getCategory());
 	if (!hasImbuementType(static_cast<ImbuementTypes_t>(categoryImbuement->id), imbuement->getBaseID())) {
-		return;
+		return false;
 	}
 
 	// Checks if the item already has the imbuement category id
 	if (hasImbuementCategoryId(categoryImbuement->id)) {
 		g_logger().error("[Item::setImbuement] - An error occurred while player with name {} try to apply imbuement, item already contains imbuement of the same type: {}", player->getName(), imbuement->getName());
 		player->sendImbuementResult("An error ocurred, please reopen imbuement window.");
-		return;
+		return false;
 	}
 
 	setImbuement(slot, imbuementId, duration);
+
+	return true;
 }
 
 bool Item::hasImbuementCategoryId(uint16_t categoryId) const {

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -122,7 +122,7 @@ void Item::setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
 	setCustomAttribute(std::to_string(ITEM_IMBUEMENT_SLOT + slot), valueDuration);
 }
 
-void Item::addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
+bool Item::addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
 	const auto &player = getHoldingPlayer();
 	if (!player) {
 		return false;

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -670,7 +670,7 @@ public:
 	 * @return false
 	 */
 	bool getImbuementInfo(uint8_t slot, ImbuementInfo* imbuementInfo) const;
-	void addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration);
+	bool addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration);
 	/**
 	 * @brief Decay imbuement time duration, only use this for decay the imbuement time
 	 *


### PR DESCRIPTION
Previously, the addImbuement function was called after the stats were applied, which allowed players to exploit the system using bot scripts to stack multiple imbuements without proper validation.

This fix moves the addImbuement call earlier in the logic and checks its return value to ensure the imbuement was successfully applied before proceeding to update the player's stats.
