### PR TITLE
fix: validate amount before removing value from players bank

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2659,6 +2659,68 @@ std::shared_ptr<Item> Game::findItemOfType(const std::shared_ptr<Cylinder> &cyli
 	return nullptr;
 }
 
+bool Game::validRemoveMoney(const std::shared_ptr<Cylinder> &cylinder, uint64_t money, uint32_t flags /*= 0*/, bool useBalance /*= false*/) {
+	if (cylinder == nullptr) {
+		g_logger().error("[{}] cylinder is nullptr", __FUNCTION__);
+		return false;
+	}
+	if (money == 0) {
+		return true;
+	}
+
+	std::vector<std::shared_ptr<Container>> containers;
+	std::multimap<uint32_t, std::shared_ptr<Item>> moneyMap;
+	uint64_t moneyCount = 0;
+	for (size_t i = cylinder->getFirstIndex(), j = cylinder->getLastIndex(); i < j; ++i) {
+		const std::shared_ptr<Thing> &thing = cylinder->getThing(i);
+		if (!thing) {
+			continue;
+		}
+		const auto &item = thing->getItem();
+		if (!item) {
+			continue;
+		}
+		const std::shared_ptr<Container> &container = item->getContainer();
+		if (container) {
+			containers.push_back(container);
+		} else {
+			const uint32_t worth = item->getWorth();
+			if (worth != 0) {
+				moneyCount += worth;
+				moneyMap.emplace(worth, item);
+			}
+		}
+	}
+	size_t i = 0;
+	while (i < containers.size()) {
+		const std::shared_ptr<Container> &container = containers[i++];
+		for (const std::shared_ptr<Item> &item : container->getItemList()) {
+			const std::shared_ptr<Container> &tmpContainer = item->getContainer();
+			if (tmpContainer) {
+				containers.push_back(tmpContainer);
+			} else {
+				const uint32_t worth = item->getWorth();
+				if (worth != 0) {
+					moneyCount += worth;
+					moneyMap.emplace(worth, item);
+				}
+			}
+		}
+	}
+
+	const auto &player = useBalance ? std::dynamic_pointer_cast<Player>(cylinder) : nullptr;
+	uint64_t balance = 0;
+	if (useBalance && player) {
+		balance = player->getBankBalance();
+	}
+
+	if (moneyCount + balance < money) {
+		return false;
+	}
+
+	return true;
+}
+
 bool Game::removeMoney(const std::shared_ptr<Cylinder> &cylinder, uint64_t money, uint32_t flags /*= 0*/, bool useBalance /*= false*/) {
 	if (cylinder == nullptr) {
 		g_logger().error("[{}] cylinder is nullptr", __FUNCTION__);

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -239,6 +239,8 @@ public:
 
 	void createLuaItemsOnMap();
 
+	bool validRemoveMoney(const std::shared_ptr<Cylinder> &cylinder, uint64_t money, uint32_t flags = 0, bool useBank = false);
+
 	bool removeMoney(const std::shared_ptr<Cylinder> &cylinder, uint64_t money, uint32_t flags = 0, bool useBank = false);
 
 	void addMoney(const std::shared_ptr<Cylinder> &cylinder, uint64_t money, uint32_t flags = 0);

--- a/src/lua/functions/creatures/npc/npc_functions.cpp
+++ b/src/lua/functions/creatures/npc/npc_functions.cpp
@@ -644,6 +644,15 @@ int NpcFunctions::luaNpcSellItem(lua_State* L) {
 		}
 	}
 
+	const auto totalCost = amount * pricePerUnit;
+
+	if (!g_game().validRemoveMoney(player, totalCost, 0, true)) {
+		Lua::pushBoolean(L, false);
+		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+		g_logger().error("[NpcFunctions::luaNpcSellItem (validRemoveMoney)] - Player {} possibly tried to abuse a bug buying large amounts of {} on shop for npc {}", player->getName(), itemId, npc->getName());
+		return 1;
+	}
+
 	const auto &[_, itemsPurchased, backpacksPurchased] = g_game().createItem(player, itemId, amount, subType, actionId, ignoreCap, inBackpacks ? ITEM_SHOPPING_BAG : 0);
 
 	std::stringstream ss;


### PR DESCRIPTION
Added a validation function (`validRemoveMoney`) to ensure the value being removed is valid before completing the transaction.

This fixes a bug where players could buy items from NPCs without sufficient funds. The issue appears to stem from a mismatch in total value calculation in the NPC trade window, allowing purchases without the required money.

The original `removeMoney` logic was copied and adjusted in `validRemoveMoney` to properly validate the transaction beforehand.

![433494444-6e65fce0-4cdc-4d99-83fe-6423a33c1f18 (1)](https://github.com/user-attachments/assets/55c1cd1f-3c60-4fbd-aea2-cffb150281bb)


