### PR TITLE
[fix] disable mount in outfit window

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6189,7 +6189,7 @@ void Game::playerToggleMount(uint32_t playerId, bool mount) {
 	player->setNextExAction(OTSYS_TIME() + g_configManager().getNumber(UI_ACTIONS_DELAY_INTERVAL) - 10);
 }
 
-void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMountRandomized /* = 0*/) {
+void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool isMounted, /* = false */  uint8_t isMountRandomized /* = 0*/) {
 	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT)) {
 		return;
 	}
@@ -6203,7 +6203,7 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMoun
 		return;
 	}
 
-	if (player->isWearingSupportOutfit()) {
+	if (player->isWearingSupportOutfit() || !isMounted) {
 		outfit.lookMount = 0;
 		isMountRandomized = 0;
 	}

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -408,7 +408,7 @@ public:
 	void playerShowQuestLog(uint32_t playerId);
 	void playerShowQuestLine(uint32_t playerId, uint16_t questId);
 	void playerSay(uint32_t playerId, uint16_t channelId, SpeakClasses type, const std::string &receiver, const std::string &text);
-	void playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMountRandomized = 0);
+	void playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool isMounted = false, uint8_t isMountRandomized = 0);
 	void playerInviteToParty(uint32_t playerId, uint32_t invitedId);
 	void playerJoinParty(uint32_t playerId, uint32_t leaderId);
 	void playerRevokePartyInvitation(uint32_t playerId, uint32_t invitedId);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1721,9 +1721,9 @@ void ProtocolGame::parseSetOutfit(NetworkMessage &msg) {
 				g_logger().debug("Bool isMounted: {}", isMounted);
 
 				uint8_t isMountRandomized = msg.getByte();
-				g_game().playerChangeOutfit(player->getID(), newOutfit, isMountRandomized);
+				g_game().playerChangeOutfit(player->getID(), newOutfit, isMounted, isMountRandomized);
 			} else {
-				g_game().playerChangeOutfit(player->getID(), newOutfit, 0);
+				g_game().playerChangeOutfit(player->getID(), newOutfit, false, 0);
 			}
 		} else if (outfitType == 1) {
 			// This value probably has something to do with try outfit variable inside outfit window dialog


### PR DESCRIPTION
Previously, the "disable mount" option in the outfit window was not functioning correctly, allowing players to dismount only via the CTRL + R shortcut.

This fix adds a proper check for the `isMounted` value to ensure the mount state is correctly handled through the outfit window.