### PR TITLE
fix: container auto scroll while moving items

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -761,7 +761,8 @@ void Creature::changeHealth(int32_t healthChange, bool sendHealthChange /* = tru
 					creature->onDeath();
 				}
 			}
-		}, "Creature::onDeath");
+		},
+		                        "Creature::onDeath");
 	}
 }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6174,7 +6174,7 @@ void Game::playerToggleMount(uint32_t playerId, bool mount) {
 	player->setNextExAction(OTSYS_TIME() + g_configManager().getNumber(UI_ACTIONS_DELAY_INTERVAL) - 10);
 }
 
-void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool isMounted, /* = false */  uint8_t isMountRandomized /* = 0*/) {
+void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool isMounted, /* = false */ uint8_t isMountRandomized /* = 0*/) {
 	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT)) {
 		return;
 	}
@@ -10760,14 +10760,14 @@ ReturnValue Game::beforeCreatureZoneChange(const std::shared_ptr<Creature> &crea
 	}
 
 	// fromZones - toZones = zones that creature left
-	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
-		return toZones.find(z) == toZones.end();
-	});
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto &z) {
+							return toZones.find(z) == toZones.end();
+						});
 
 	// toZones - fromZones = zones that creature entered
-	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
-		return fromZones.find(z) == fromZones.end();
-	});
+	auto zonesEntering = toZones | std::views::filter([&](const auto &z) {
+							 return fromZones.find(z) == fromZones.end();
+						 });
 
 	if (zonesLeaving.empty() && zonesEntering.empty()) {
 		return RETURNVALUE_NOERROR;
@@ -10795,14 +10795,14 @@ void Game::afterCreatureZoneChange(const std::shared_ptr<Creature> &creature, co
 	}
 
 	// fromZones - toZones = zones that creature left
-	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
-		return toZones.find(z) == toZones.end();
-	});
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto &z) {
+							return toZones.find(z) == toZones.end();
+						});
 
 	// toZones - fromZones = zones that creature entered
-	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
-		return fromZones.find(z) == fromZones.end();
-	});
+	auto zonesEntering = toZones | std::views::filter([&](const auto &z) {
+							 return fromZones.find(z) == fromZones.end();
+						 });
 
 	for (const auto &zone : zonesLeaving) {
 		zone->creatureRemoved(creature);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2249,16 +2249,10 @@ ReturnValue Game::internalMoveItem(std::shared_ptr<Cylinder> fromCylinder, std::
 
 	auto fromContainer = fromCylinder ? fromCylinder->getContainer() : nullptr;
 	auto toContainer = toCylinder ? toCylinder->getContainer() : nullptr;
-	auto player = actor ? actor->getPlayer() : nullptr;
-	if (player) {
-		// Update containers
-		player->onSendContainer(toContainer);
-		player->onSendContainer(fromContainer);
-	}
 
 	// Actor related actions
 	if (fromCylinder && actor && toCylinder) {
-		if (!fromContainer || !toContainer || !player) {
+		if (!fromContainer || !toContainer) {
 			return ret;
 		}
 


### PR DESCRIPTION
Now you can move items to a container and it does not auto scroll
thanks to @jpaulooliveira