### PR TITLE
feature: adapt AddPlayerSkills to 14.12 protocol

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2409,6 +2409,7 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 		addItemImbuementStats(imbuement);
 	}
 
+	sendSkills(); // skills need to be updated because now it shows in the player skills window
 	updateImbuementTrackerStats();
 	openImbuementWindow(item);
 }
@@ -2445,6 +2446,7 @@ void Player::onClearImbuement(const std::shared_ptr<Item> &item, uint8_t slot) {
 	}
 
 	item->clearImbuement(slot, imbuementInfo.imbuement->getID());
+	sendSkills(); // skills need to be updated because now it shows in the player skills window
 	updateImbuementTrackerStats();
 	this->openImbuementWindow(item);
 }

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -131,7 +131,7 @@ namespace {
 	 */
 	void handleImbuementDamage(NetworkMessage &msg, const std::shared_ptr<Player> &player) {
 		bool imbueDmg = false;
-		std::shared_ptr<Item> weapon = player->getWeapon();
+		std::shared_ptr<Item> weapon = player->getWeapon(CONST_SLOT_LEFT);
 		if (weapon) {
 			uint8_t slots = Item::items[weapon->getID()].imbuementSlot;
 			if (slots > 0) {
@@ -144,7 +144,7 @@ namespace {
 					if (imbuementInfo.duration > 0) {
 						auto imbuement = *imbuementInfo.imbuement;
 						if (imbuement.combatType != COMBAT_NONE) {
-							msg.addByte(static_cast<uint32_t>(imbuement.elementDamage));
+							msg.addDouble(static_cast<double>(imbuement.elementDamage)/100);
 							msg.addByte(getCipbiaElement(imbuement.combatType));
 							imbueDmg = true;
 							break;
@@ -154,8 +154,8 @@ namespace {
 			}
 		}
 		if (!imbueDmg) {
-			msg.addByte(0);
-			msg.addByte(0);
+			msg.addDouble(0x00); // converted damage
+			msg.addByte(CIPBIA_ELEMENTAL_PHYSICAL); // getCipbiaElement
 		}
 	}
 
@@ -237,7 +237,7 @@ namespace {
 				int16_t clientModifier = std::clamp(10000 - static_cast<int16_t>(damageModifiers[i]), -10000, 10000);
 				g_logger().debug("[{}] CombatType: {}, Damage Modifier: {}, Resulting Client Modifier: {}", __FUNCTION__, i, damageModifiers[i], clientModifier);
 				msg.addByte(getCipbiaElement(indexToCombatType(i)));
-				msg.add<int16_t>(clientModifier);
+				msg.addDouble(clientModifier/10000.0, 4);
 				++combats;
 			}
 		}
@@ -7960,39 +7960,212 @@ void ProtocolGame::AddPlayerSkills(NetworkMessage &msg) {
 		}
 	}
 
+	// the addDouble needs to pass a parameter precision to work properly, i'm using 5 for now but still need to check
 	if (!oldProtocol) {
 		msg.addByte(0x00); // unknown
 		msg.add<uint32_t>(player->getCapacity()); // total capacity
 		msg.add<uint32_t>(player->getBaseCapacity()); // base total capacity
-		msg.add<uint16_t>(0x00); // damage / healing
-		msg.add<uint16_t>(0x00); // max damage
-		msg.addByte(0x00); // CIPBIA ELEMENTAL
-		msg.addDouble(0x00); // damage
-		msg.addByte(0x00); // getCipbiaElement
-		msg.addDouble(0x00); // life leech
-		msg.addDouble(0x00); // mana leech
-		msg.addDouble(0x00); // critical
-		msg.addDouble(0x00); // critical hit damage
-		msg.addDouble(0x00); // ONSLAUGHT
 
-		msg.add<uint16_t>(player->getArmor());
+
+		// damage/healing, max damage and converted damage based on weapon type
+		std::shared_ptr<Item> weapon = player->getWeapon(CONST_SLOT_LEFT);
+		if (weapon) {
+			const ItemType &it = Item::items[weapon->getID()];
+			if (it.weaponType == WEAPON_WAND) {
+					msg.add<uint16_t>(it.maxHitChance/100); // damage / healing
+					msg.addByte(it.abilities->elementType); // getCipbiaElement
+
+					msg.addByte(static_cast<uint32_t>(it.maxHitChance) / 100); // max damage
+					msg.addByte(getCipbiaElement(it.abilities->elementType)); // getCipbiaElement
+
+					msg.addDouble(0x00); // converted damage
+					msg.addByte(CIPBIA_ELEMENTAL_ENERGY); // getCipbiaElement
+
+			} else if (it.weaponType == WEAPON_DISTANCE || it.weaponType == WEAPON_AMMO || it.weaponType == WEAPON_MISSILE) {
+				int32_t attackValue = weapon->getAttack();
+				if (it.weaponType == WEAPON_AMMO) {
+					std::shared_ptr<Item> weaponItem = player->getWeapon(true);
+					if (weaponItem) {
+						attackValue += weaponItem->getAttack();
+					}
+				}
+
+				int32_t attackSkill = player->getSkillLevel(SKILL_DISTANCE);
+				float attackFactor = player->getAttackFactor();
+				uint32_t maxDamage = static_cast<uint32_t>(Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor, true) * player->getVocation()->distDamageMultiplier);
+				if (it.abilities && it.abilities->elementType != COMBAT_NONE) {
+					maxDamage += static_cast<uint32_t>(Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue - weapon->getAttack() + it.abilities->elementDamage, attackFactor, true) * player->getVocation()->distDamageMultiplier);
+				}
+
+				if (attackValue) {
+					msg.add<uint16_t>(attackValue);   // damage / healing
+				} else {
+					msg.addByte(0);
+				}
+
+				msg.add<uint16_t>(maxDamage); // max damage
+				msg.addByte(CIPBIA_ELEMENTAL_PHYSICAL);  // getCipbiaElement
+
+				if (it.abilities && it.abilities->elementType != COMBAT_NONE) {
+					
+				} else {
+					handleImbuementDamage(msg, player);   // converted damage
+				}
+
+			} else {
+				int32_t attackValue = std::max<int32_t>(0, weapon->getAttack());
+				int32_t attackSkill = player->getWeaponSkill(weapon);
+				float attackFactor = player->getAttackFactor();
+				uint32_t maxDamage = static_cast<uint32_t>(Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor, true) * player->getVocation()->meleeDamageMultiplier);
+				if (it.abilities && it.abilities->elementType != COMBAT_NONE) {
+					maxDamage += static_cast<uint32_t>(Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, it.abilities->elementDamage, attackFactor, true) * player->getVocation()->meleeDamageMultiplier);
+				}
+		
+				if (attackValue) {
+						msg.add<uint16_t>(attackValue);  // damage / healing
+					} else {
+						msg.addByte(0);
+					}
+					msg.add<uint16_t>(maxDamage);  // max damage
+					msg.addByte(CIPBIA_ELEMENTAL_PHYSICAL); 
+
+					handleImbuementDamage(msg, player);   // converted damage
+				}
+		} else {
+			float attackFactor = player->getAttackFactor();
+			int32_t attackSkill = player->getSkillLevel(SKILL_FIST);
+			int32_t attackValue = 7;
+
+			int32_t maxDamage = Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor, true);
+
+			msg.add<uint16_t>(attackValue); // damage / healing
+
+			msg.add<uint16_t>(maxDamage);  // max damage
+			msg.addByte(CIPBIA_ELEMENTAL_PHYSICAL);
+
+			 msg.addDouble(0x00); // converted damage
+			 msg.addByte(CIPBIA_ELEMENTAL_ENERGY); // getCipbiaElement
+
+		}
+
+		const auto lifeLeechAmount = player->getSkillLevel(SKILL_LIFE_LEECH_AMOUNT) / 10;
+		const auto manaLeechAmount = player->getSkillLevel(SKILL_MANA_LEECH_AMOUNT) / 10;
+		const auto criticalChance = player->getSkillLevel(SKILL_CRITICAL_HIT_CHANCE) / 10;
+		const auto criticalDamage = player->getSkillLevel(SKILL_CRITICAL_HIT_DAMAGE) / 10;
+
+		if (lifeLeechAmount > 0) {
+			msg.addDouble(lifeLeechAmount, 5); // 5 means the precision - check which is correct
+		} else {
+			msg.addDouble(0x00);
+		}
+		if (manaLeechAmount > 0) {
+			msg.addDouble(manaLeechAmount, 5);  // 5 means the precision - check which is correct
+		} else {
+			msg.addDouble(0x00);
+		}
+		if (criticalChance > 0) {
+			msg.addDouble(criticalChance, 5);  // 5 means the precision - check which is correct
+		} else {
+			msg.addDouble(0x00);
+		}
+		if (criticalDamage > 0) {
+			msg.addDouble(criticalDamage, 5);  // 5 means the precision - check which is correct
+		} else {
+			msg.addDouble(0x00);
+		}
+		
+
+		double_t amplificationChance = 0;
+		if (const auto &feetItem = player->getInventoryItem(CONST_SLOT_FEET); feetItem) {
+			amplificationChance += 0; //feetItem->getAmplificationChance(); // code prepared for the amplification feature.
+		}
+
+		double_t onslaught = 0;
+		if (const auto &item = player->getInventoryItem(CONST_SLOT_LEFT); item) {
+			const ItemType &it = Item::items[item->getID()];
+			if (it.isWeapon()) {
+				onslaught = item->getFatalChance() / 100.0;
+			}
+			onslaught += onslaught * amplificationChance;
+			msg.addDouble(onslaught, 5);  // 5 means the precision - check which is correct
+		} else {
+			msg.addDouble(0x00); // ONSLAUGHT
+		}
+
 		msg.add<uint16_t>(player->getDefense());
+		msg.add<uint16_t>(player->getArmor());
+		
 
 		// Wheel of destiny mitigation
 		if (g_configManager().getBoolean(TOGGLE_WHEELSYSTEM)) {
-			msg.addDouble(player->getMitigation()); // FIX ME wrong value
+			msg.addDouble(player->getMitigation()/10, 5); // 5 means the precision - check which is correct
 		} else {
 			msg.addDouble(0);
 		}
 
-		msg.addDouble(0x00); // ruse
-		msg.add<uint16_t>(static_cast<uint16_t>(player->getReflectFlat(COMBAT_PHYSICALDAMAGE)));
-		msg.addByte(0x00); // size protections (se maior que 1 ativar 1 Byte e 1 Double)
-		// msg.addByte(0x00); // getCipbiaElement
-		// msg.addDouble(0x00); // value protection
-		msg.addDouble(0x00); // Momentum
-		msg.addDouble(0x00); // trancedance
-		msg.addDouble(0x00); // amplification
+
+		double_t ruse = 0;
+		if (const auto &item = player->getInventoryItem(CONST_SLOT_ARMOR); item) {
+			const ItemType &it = Item::items[item->getID()];
+			if (it.isArmor()) {
+				ruse = item->getDodgeChance() / 100.0;
+			}
+			ruse += ruse * amplificationChance;
+			msg.addDouble(ruse, 5);
+		} else {
+			msg.addDouble(0x00); // ruse
+		}
+
+
+		msg.add<uint16_t>(static_cast<uint16_t>(player->getReflectFlat(COMBAT_PHYSICALDAMAGE))); // Reflect
+
+
+		// Store the "combats" to increase in absorb values function and send to client later
+		uint8_t combats = 0;
+		auto startCombats = msg.getBufferPosition();
+		msg.skipBytes(1);
+		// Calculate and parse the combat absorbs values
+		calculateAbsorbValues(player, msg, combats);
+		// Now set the buffer position skiped and send the total combats count
+		auto endCombats = msg.getBufferPosition();
+		msg.setBufferPosition(startCombats);
+		msg.addByte(combats);
+		msg.setBufferPosition(endCombats);
+
+	
+
+
+		double_t momentum = 0;
+		if (const auto &item = player->getInventoryItem(CONST_SLOT_HEAD); item) {
+			const ItemType &it = Item::items[item->getID()];
+			if (it.isHelmet()) {
+				momentum = item->getMomentumChance() / 100.0;
+			}
+			momentum += momentum * amplificationChance;
+			msg.addDouble(momentum, 5);
+		} else {
+			msg.addDouble(0x00); // momentum
+		}
+
+		double_t transcendence = 0;
+		if (const auto &item = player->getInventoryItem(CONST_SLOT_LEGS); item) {
+			const ItemType &it = Item::items[item->getID()];
+			if (it.isLegs()) {
+				transcendence = item->getTranscendenceChance() / 100.0;
+			}
+			transcendence += transcendence * amplificationChance;
+			msg.addDouble(transcendence, 5);
+		} else {
+			msg.addDouble(0x00); // transcendence
+		}
+
+		if (amplificationChance > 0) {
+			msg.addDouble(amplificationChance, 5); // amplification
+		} else {
+			msg.addDouble(0x00); // amplification
+		}
+	
+
 		writeToOutputBuffer(msg);
 	}
 }


### PR DESCRIPTION
Initial implementation of the new AddPlayerSkills to support the updated protocol structure.

🔍 Things to review and improve:

The following still needs to be checked and properly calculated:
- Damage/Healing
- Attack Value
- Converted Damage

msg:addDouble() requires a precision parameter. I'm currently using 5 for testing purposes — this seems to work, but it's unclear for me if it's the ideal value for every case.

It may also be worth refactoring the function for better readability and maintainability.

⚠️ Notes:
This is an initial commit for the feature and still needs polishing.

![Capturar](https://github.com/user-attachments/assets/5e137c70-b021-4bbf-8b76-5e66888226ff)

