### PR TITLE
fix: add taint experience boost for Soul War monsters

### DIFF
--- a/data-global/lib/quests/soul_war.lua
+++ b/data-global/lib/quests/soul_war.lua
@@ -23,6 +23,14 @@ SoulWarQuest = {
 		[34007] = 0.10, -- 10% for the smallest pool
 	},
 
+	taintExperienceBoostMap = { -- Experience Boost per taint (In percentage %)
+		[1] = { boost = 4.5 },
+		[2] = { boost = 9.2 },
+		[3] = { boost = 14.1 },
+		[4] = { boost = 19.2 },
+		[5] = { boost = 24.6 },
+	},
+
 	timeToIncreaseCrueltyDefense = 15, -- In seconds, it will increase every 15 seconds if don't use mortal essence in greedy maw
 	useGreedMawCooldown = 30, -- In seconds
 	goshnarsCrueltyDefenseChange = 2, -- Defense change, the amount that will decrease or increase defense, the defense cannot decrease more than the monster's original defense amount

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -581,10 +581,21 @@ function Player:onGainExperience(target, exp, rawExp)
 		local stack = target:getForgeStack()
 		if stack >= 1 and stack <= 15 then
 			stackBonus = math.min(stack * 10, 150)
+			exp = exp * (1 + stackBonus / 100)
 		end
 	end
 
-	exp = exp * (1 + stackBonus / 100)
+	-- Soul War Experience by Taint
+	if SoulWarQuest then
+		local monsterType = target:getType()
+		if monsterType and monsterType:getName() and table.contains(SoulWarQuest.bagYouDesireMonsters, monsterType:getName()) then
+			local taintLevel = self:getTaintLevel()
+			if taintLevel > 0 then
+				local taintBoost = SoulWarQuest.taintExperienceBoostMap[taintLevel] and SoulWarQuest.taintExperienceBoostMap[taintLevel].boost or 0
+				exp = exp * (1 + taintBoost / 100)
+			end
+		end
+	end
 
 	-- Final Adjustments: Low Level Bonus and Base Rate
 	local lowLevelBonusExp = self:getFinalLowLevelBonus()

--- a/data/libs/systems/hazard.lua
+++ b/data/libs/systems/hazard.lua
@@ -171,7 +171,6 @@ function Hazard:register()
 		player:setHazardSystemPoints(0)
 	end
 
-
 	function event.onSpawn(creature, position)
 		local monster = creature:getMonster()
 		if not monster then
@@ -182,7 +181,7 @@ function Hazard:register()
 		if not zones then
 			return true
 		end
-	
+
 		for _, zone in ipairs(zones) do
 			local hazard = Hazard.getByName(zone:getName())
 			if hazard then


### PR DESCRIPTION
This PR introduces a fix and enhancement for the experience boost system related to the Soul War quest. Specifically, it ensures that the player's taint level is correctly factored into the experience calculation when defeating monsters listed in SoulWarQuest.bagYouDesireMonsters.

thanks to @FelipePaluco