### PR TITLE
fix: gamestore exp boost price

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -2077,16 +2077,8 @@ function Player.makeCoinTransaction(self, offer, desc)
 		if expBoostCount == -1 or expBoostCount == 0 or expBoostCount > 5 then
 			expBoostCount = 1
 		end
-		if expBoostCount <= 1 then
-			offer.price = GameStore.ExpBoostValues[1]
-		elseif expBoostCount == 2 then
-			offer.price = GameStore.ExpBoostValues[2]
-		elseif expBoostCount == 3 then
-			offer.price = GameStore.ExpBoostValues[3]
-		elseif expBoostCount == 4 then
-			offer.price = GameStore.ExpBoostValues[4]
-		elseif expBoostCount == 5 then
-			offer.price = GameStore.ExpBoostValues[5]
+		if GameStore.ExpBoostValues[expBoostCount] then
+			offer.price = GameStore.ExpBoostValues[expBoostCount]
 		else
 			offer.price = offer.price
 		end

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1787,7 +1787,7 @@ function GameStore.processExpBoostPurchase(player)
 	player:setXpBoostPercent(50)
 	player:setXpBoostTime(currentXpBoostTime + 3600)
 
-	if expBoostCount == -1 or expBoostCount > 0 or expBoostCount > 5 then
+	if expBoostCount == -1 or expBoostCount > 5 then
 		expBoostCount = 1
 	end
 end
@@ -2071,7 +2071,7 @@ function Player.makeCoinTransaction(self, offer, desc)
 		desc = offer.name
 	end
 
-	if offer.Type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST or GameStore.OfferTypes.OFFER_TYPE_EXPBOOSTCUSTOM then
+	if offer.Type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST then
 		local expBoostCount = self:getStorageValue(GameStore.Storages.expBoostCount)
 
 		if expBoostCount == -1 or expBoostCount == 0 or expBoostCount > 5 then

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1787,11 +1787,9 @@ function GameStore.processExpBoostPurchase(player)
 	player:setXpBoostPercent(50)
 	player:setXpBoostTime(currentXpBoostTime + 3600)
 
-	if expBoostCount == -1 or expBoostCount == 6 then
+	if expBoostCount == -1 or expBoostCount > 0 or expBoostCount > 5 then
 		expBoostCount = 1
 	end
-
-	player:setStorageValue(GameStore.Storages.expBoostCount, expBoostCount + 1)
 end
 
 function GameStore.processPreyThirdSlot(player)
@@ -2071,6 +2069,28 @@ function Player.makeCoinTransaction(self, offer, desc)
 		desc = offer.name .. " (" .. desc .. ")"
 	else
 		desc = offer.name
+	end
+
+	if offer.Type == GameStore.OfferTypes.OFFER_TYPE_EXPBOOST or GameStore.OfferTypes.OFFER_TYPE_EXPBOOSTCUSTOM then
+		local expBoostCount = self:getStorageValue(GameStore.Storages.expBoostCount)
+
+		if expBoostCount == -1 or expBoostCount == 0 or expBoostCount > 5 then
+			expBoostCount = 1
+		end
+		if expBoostCount <= 1 then
+			offer.price = GameStore.ExpBoostValues[1]
+		elseif expBoostCount == 2 then
+			offer.price = GameStore.ExpBoostValues[2]
+		elseif expBoostCount == 3 then
+			offer.price = GameStore.ExpBoostValues[3]
+		elseif expBoostCount == 4 then
+			offer.price = GameStore.ExpBoostValues[4]
+		elseif expBoostCount == 5 then
+			offer.price = GameStore.ExpBoostValues[5]
+		else
+			offer.price = offer.price
+		end
+		self:setStorageValue(GameStore.Storages.expBoostCount, expBoostCount + 1)
 	end
 
 	if offer.coinType == GameStore.CoinType.Coin and self:canRemoveCoins(offer.price) then


### PR DESCRIPTION
By applying this modification, it will function correctly, and the correct amount of exp boost will be visually charged.

ty @LeoTKBR