### PR TITLE
fix Field Runes

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -81327,6 +81327,9 @@ Granted by TibiaGoals.com" />
 		<attribute key="decayTo" value="49150" />
 		<attribute key="duration" value="5" />
 	</item>
+	<item id="49161" name="stairs">
+		<attribute key="floorchange" value="down" />
+	</item>
 	<item id="49163" article="an" name="ominous soul core">
 		<attribute key="primarytype" value="soul cores" />
 		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core." />
@@ -81335,9 +81338,6 @@ Granted by TibiaGoals.com" />
 	<item id="49164" article="a" name="soul prism">
 		<attribute key="description" value="Focalises the soul within a core. Can be used to turn a soul core into a greater version" />
 		<attribute key="weight" value="100" />
-	</item>
-	<item id="49161" name="stairs">
-		<attribute key="floorchange" value="down" />
 	</item>
 	<item id="49271" article="a" name="transcendence potion">
 		<attribute key="primarytype" value="liquids" />
@@ -82986,8 +82986,12 @@ Granted by TibiaGoals.com" />
 		<attribute key="description" value="Offers a soul to the Soulpit. Combine with another soul core to create a random new soul core." />
 		<attribute key="weight" value="100" />
 	</item>
-	<item id="50122" article="a" name="stair" />
-	<item id="50123" article="a" name="stair" />
+	<item id="50122" article="a" name="ladder" >
+		<attribute key="type" value="ladder" />
+	</item>
+	<item id="50123" article="a" name="ladder" >
+		<attribute key="type" value="ladder" />
+	</item>
 	<item id="50124" article="a" name="arbaziloth santa">
 		<attribute key="primarytype" value="dolls and bears" />
 		<attribute key="weight" value="100" />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -4344,65 +4344,38 @@
 		</attribute>
 	</item>
 	<item id="2131" article="a" name="fire field">
+		<attribute key="primarytype" value="fields" />
 		<attribute key="type" value="magicfield" />
-		<attribute key="field" value="fire">
-			<attribute key="ticks" value="10000" />
-			<attribute key="count" value="7" />
-			<attribute key="damage" value="20" />
-		</attribute>
+		<attribute key="field" value="fire" />
 		<attribute key="duration" value="120" />
 		<attribute key="decayTo" value="2132" />
-		<attribute key="script" value="moveevent">
-			<attribute key="eventType" value="stepin" />
-		</attribute>
 	</item>
 	<item id="2132" article="a" name="fire field">
+		<attribute key="primarytype" value="fields" />
 		<attribute key="type" value="magicfield" />
-		<attribute key="field" value="fire">
-			<attribute key="ticks" value="10000" />
-			<attribute key="count" value="7" />
-			<attribute key="damage" value="10" />
-		</attribute>
+		<attribute key="field" value="fire" />
 		<attribute key="duration" value="120" />
 		<attribute key="decayTo" value="2133" />
-		<attribute key="script" value="moveevent">
-			<attribute key="eventType" value="stepin" />
-		</attribute>
 	</item>
 	<item id="2133" article="a" name="fire field">
+		<attribute key="primarytype" value="fields" />
 		<attribute key="type" value="magicfield" />
 		<attribute key="field" value="fire" />
 		<attribute key="duration" value="120" />
 		<attribute key="decayTo" value="0" />
-		<attribute key="script" value="moveevent">
-			<attribute key="eventType" value="stepin" />
-		</attribute>
 	</item>
 	<item id="2134" article="a" name="poison gas">
 		<attribute key="primarytype" value="fields" />
 		<attribute key="type" value="magicfield" />
-		<attribute key="field" value="poison">
-			<attribute key="ticks" value="5000" />
-			<attribute key="damage" value="100" />
-			<attribute key="start" value="5" />
-		</attribute>
+		<attribute key="field" value="poison"/>
 		<attribute key="duration" value="120" />
 		<attribute key="decayTo" value="0" />
-		<attribute key="script" value="moveevent">
-			<attribute key="eventType" value="stepin" />
-		</attribute>
 	</item>
 	<item id="2135" article="an" name="energy field">
+		<attribute key="primarytype" value="fields" />
 		<attribute key="type" value="magicfield" />
-		<attribute key="field" value="energy">
-			<attribute key="ticks" value="10000" />
-			<attribute key="damage" value="25" />
-		</attribute>
 		<attribute key="duration" value="120" />
 		<attribute key="decayTo" value="0" />
-		<attribute key="script" value="moveevent">
-			<attribute key="eventType" value="stepin" />
-		</attribute>
 	</item>
 	<item id="2136" name="smoke">
 		<attribute key="primarytype" value="fields" />
@@ -42626,17 +42599,10 @@ My sad story is told by few living humans but many dead warriors" />
 		<attribute key="decayTo" value="7359" />
 	</item>
 	<item id="21465" article="a" name="fire field">
+		<attribute key="primarytype" value="fields" />
 		<attribute key="type" value="magicfield" />
-		<attribute key="field" value="fire">
-			<attribute key="ticks" value="10000" />
-			<attribute key="count" value="7" />
-			<attribute key="damage" value="10" />
-		</attribute>
 		<attribute key="duration" value="120" />
 		<attribute key="decayTo" value="2132" />
-		<attribute key="script" value="moveevent">
-			<attribute key="eventType" value="stepin" />
-		</attribute>
 	</item>
 	<item id="21466" name="ewer with holy water">
 		<attribute key="description" value="The water in the ewer shimmers faintly. In the desert's heat it will evaporate soon, however" />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -81336,6 +81336,9 @@ Granted by TibiaGoals.com" />
 		<attribute key="description" value="Focalises the soul within a core. Can be used to turn a soul core into a greater version" />
 		<attribute key="weight" value="100" />
 	</item>
+	<item id="49161" name="stairs">
+		<attribute key="floorchange" value="down" />
+	</item>
 	<item id="49271" article="a" name="transcendence potion">
 		<attribute key="primarytype" value="liquids" />
 		<attribute key="description" value="Drinking this potion temporarily increases your fist skill" />

--- a/data/scripts/movements/fields/energy_field.lua
+++ b/data/scripts/movements/fields/energy_field.lua
@@ -5,23 +5,23 @@ energyCondition:setParameter(CONDITION_PARAM_DELAYED, true)
 energyCondition:addDamage(5, 2000, -25)
 
 function energyField.onStepIn(creature, item, position, fromPosition)
-    if not creature:isCreature() then
-        return true
-    end
+	if not creature:isCreature() then
+		return true
+	end
 
-    if creature:isPlayer() and creature:getGroup():getId() >= 2 then
-        return true
-    end
+	if creature:isPlayer() and creature:getGroup():getId() >= 2 then
+		return true
+	end
 
-    if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
-        position:sendMagicEffect(CONST_ME_POFF)
-        return true
-    end
+	if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
+		position:sendMagicEffect(CONST_ME_POFF)
+		return true
+	end
 
-    doTargetCombatHealth(0, creature, COMBAT_ENERGYDAMAGE, -30, -30, CONST_ME_ENERGYHIT)
-    creature:addCondition(energyCondition)
+	doTargetCombatHealth(0, creature, COMBAT_ENERGYDAMAGE, -30, -30, CONST_ME_ENERGYHIT)
+	creature:addCondition(energyCondition)
 
-    return true
+	return true
 end
 
 energyField:type("stepin")

--- a/data/scripts/movements/fields/energy_field.lua
+++ b/data/scripts/movements/fields/energy_field.lua
@@ -1,0 +1,29 @@
+local energyField = MoveEvent()
+
+local energyCondition = Condition(CONDITION_ENERGY)
+energyCondition:setParameter(CONDITION_PARAM_DELAYED, true)
+energyCondition:addDamage(5, 2000, -25)
+
+function energyField.onStepIn(creature, item, position, fromPosition)
+    if not creature:isCreature() then
+        return true
+    end
+
+    if creature:isPlayer() and creature:getGroup():getId() >= 2 then
+        return true
+    end
+
+    if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
+        position:sendMagicEffect(CONST_ME_POFF)
+        return true
+    end
+
+    doTargetCombatHealth(0, creature, COMBAT_ENERGYDAMAGE, -30, -30, CONST_ME_ENERGYHIT)
+    creature:addCondition(energyCondition)
+
+    return true
+end
+
+energyField:type("stepin")
+energyField:id(2135)
+energyField:register()

--- a/data/scripts/movements/fields/fire_field.lua
+++ b/data/scripts/movements/fields/fire_field.lua
@@ -13,28 +13,28 @@ fireCondition10:setParameter(CONDITION_PARAM_TICKS, 7000)
 fireCondition10:setParameter(CONDITION_PARAM_PERIODICDAMAGE, -10)
 
 function fireField.onStepIn(creature, item, position, fromPosition)
-    if not creature:isCreature() then
-        return true
-    end
+	if not creature:isCreature() then
+		return true
+	end
 
-    if creature:isPlayer() and creature:getGroup():getId() >= 2 then
-        return true
-    end
+	if creature:isPlayer() and creature:getGroup():getId() >= 2 then
+		return true
+	end
 
-    if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
-        position:sendMagicEffect(CONST_ME_POFF)
-        return true
-    end
+	if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
+		position:sendMagicEffect(CONST_ME_POFF)
+		return true
+	end
 
-    if item:getId() == 2132 then
-        doTargetCombatHealth(0, creature, COMBAT_FIREDAMAGE, -10, -10, CONST_ME_HITBYFIRE)
-        creature:addCondition(fireCondition10)
-    else
-        doTargetCombatHealth(0, creature, COMBAT_FIREDAMAGE, -20, -20, CONST_ME_HITBYFIRE)
-        creature:addCondition(fireCondition20)
-    end
+	if item:getId() == 2132 then
+		doTargetCombatHealth(0, creature, COMBAT_FIREDAMAGE, -10, -10, CONST_ME_HITBYFIRE)
+		creature:addCondition(fireCondition10)
+	else
+		doTargetCombatHealth(0, creature, COMBAT_FIREDAMAGE, -20, -20, CONST_ME_HITBYFIRE)
+		creature:addCondition(fireCondition20)
+	end
 
-    return true
+	return true
 end
 
 fireField:type("stepin")

--- a/data/scripts/movements/fields/fire_field.lua
+++ b/data/scripts/movements/fields/fire_field.lua
@@ -1,0 +1,42 @@
+local fireField = MoveEvent()
+
+local fireCondition20 = Condition(CONDITION_FIRE)
+fireCondition20:setParameter(CONDITION_PARAM_DELAYED, true)
+fireCondition20:setParameter(CONDITION_PARAM_TICKINTERVAL, 2000)
+fireCondition20:setParameter(CONDITION_PARAM_TICKS, 7000)
+fireCondition20:setParameter(CONDITION_PARAM_PERIODICDAMAGE, -20)
+
+local fireCondition10 = Condition(CONDITION_FIRE)
+fireCondition10:setParameter(CONDITION_PARAM_DELAYED, true)
+fireCondition10:setParameter(CONDITION_PARAM_TICKINTERVAL, 2000)
+fireCondition10:setParameter(CONDITION_PARAM_TICKS, 7000)
+fireCondition10:setParameter(CONDITION_PARAM_PERIODICDAMAGE, -10)
+
+function fireField.onStepIn(creature, item, position, fromPosition)
+    if not creature:isCreature() then
+        return true
+    end
+
+    if creature:isPlayer() and creature:getGroup():getId() >= 2 then
+        return true
+    end
+
+    if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
+        position:sendMagicEffect(CONST_ME_POFF)
+        return true
+    end
+
+    if item:getId() == 2132 then
+        doTargetCombatHealth(0, creature, COMBAT_FIREDAMAGE, -10, -10, CONST_ME_HITBYFIRE)
+        creature:addCondition(fireCondition10)
+    else
+        doTargetCombatHealth(0, creature, COMBAT_FIREDAMAGE, -20, -20, CONST_ME_HITBYFIRE)
+        creature:addCondition(fireCondition20)
+    end
+
+    return true
+end
+
+fireField:type("stepin")
+fireField:id(21465, 2131, 2132)
+fireField:register()

--- a/data/scripts/movements/fields/poison_field.lua
+++ b/data/scripts/movements/fields/poison_field.lua
@@ -10,23 +10,23 @@ poisonCondition:addDamage(10, 1000, -2)
 poisonCondition:addDamage(19, 1000, -1)
 
 function poisonField.onStepIn(creature, item, position, fromPosition)
-    if not creature:isCreature() then
-        return true
-    end
+	if not creature:isCreature() then
+		return true
+	end
 
-    if creature:isPlayer() and creature:getGroup():getId() >= 2 then
-        return true
-    end
+	if creature:isPlayer() and creature:getGroup():getId() >= 2 then
+		return true
+	end
 
-    if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
-        position:sendMagicEffect(CONST_ME_POFF)
-        return true
-    end
+	if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
+		position:sendMagicEffect(CONST_ME_POFF)
+		return true
+	end
 
-    doTargetCombatHealth(0, creature, COMBAT_EARTHDAMAGE, -10, -10, CONST_ME_POISON)
-    creature:addCondition(poisonCondition)
+	doTargetCombatHealth(0, creature, COMBAT_EARTHDAMAGE, -10, -10, CONST_ME_POISON)
+	creature:addCondition(poisonCondition)
 
-    return true
+	return true
 end
 
 poisonField:type("stepin")

--- a/data/scripts/movements/fields/poison_field.lua
+++ b/data/scripts/movements/fields/poison_field.lua
@@ -1,0 +1,34 @@
+local poisonField = MoveEvent()
+
+local poisonCondition = Condition(CONDITION_POISON)
+poisonCondition:setParameter(CONDITION_PARAM_DELAYED, true)
+
+poisonCondition:addDamage(4, 1000, -5)
+poisonCondition:addDamage(5, 1000, -4)
+poisonCondition:addDamage(7, 1000, -3)
+poisonCondition:addDamage(10, 1000, -2)
+poisonCondition:addDamage(19, 1000, -1)
+
+function poisonField.onStepIn(creature, item, position, fromPosition)
+    if not creature:isCreature() then
+        return true
+    end
+
+    if creature:isPlayer() and creature:getGroup():getId() >= 2 then
+        return true
+    end
+
+    if creature:isPlayer() or (creature:isMonster() and creature:getMaster() and creature:getMaster():isPlayer()) then
+        position:sendMagicEffect(CONST_ME_POFF)
+        return true
+    end
+
+    doTargetCombatHealth(0, creature, COMBAT_EARTHDAMAGE, -10, -10, CONST_ME_POISON)
+    creature:addCondition(poisonCondition)
+
+    return true
+end
+
+poisonField:type("stepin")
+poisonField:id(2134)
+poisonField:register()

--- a/data/scripts/runes/energy_bomb.lua
+++ b/data/scripts/runes/energy_bomb.lua
@@ -15,19 +15,19 @@ combatNoPvp:setArea(createCombatArea(AREA_SQUARE1X1))
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(55)

--- a/data/scripts/runes/energy_bomb.lua
+++ b/data/scripts/runes/energy_bomb.lua
@@ -24,7 +24,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/energy_bomb.lua
+++ b/data/scripts/runes/energy_bomb.lua
@@ -1,14 +1,32 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP)
-combat:setArea(createCombatArea(AREA_SQUARE1X1))
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP)
+combatPvp:setArea(createCombatArea(AREA_SQUARE1X1))
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_NOPVP)
+combatNoPvp:setArea(createCombatArea(AREA_SQUARE1X1))
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(55)
@@ -18,7 +36,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_ENERGY_BOMB_RUNE)
 rune:runeId(3149)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(2)
 rune:level(37)
 rune:magicLevel(10)

--- a/data/scripts/runes/energy_field.lua
+++ b/data/scripts/runes/energy_field.lua
@@ -1,13 +1,30 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP)
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP)
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_NOPVP)
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(27)
@@ -17,7 +34,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_ENERGY_FIELD_RUNE)
 rune:runeId(3164)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(3)
 rune:level(18)
 rune:magicLevel(3)

--- a/data/scripts/runes/energy_field.lua
+++ b/data/scripts/runes/energy_field.lua
@@ -13,19 +13,19 @@ combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_NOPVP)
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(27)

--- a/data/scripts/runes/energy_field.lua
+++ b/data/scripts/runes/energy_field.lua
@@ -22,7 +22,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/energy_wall.lua
+++ b/data/scripts/runes/energy_wall.lua
@@ -1,14 +1,32 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP)
-combat:setArea(createCombatArea(AREA_WALLFIELD_ENERGY, AREADIAGONAL_WALLFIELD_ENERGY))
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP)
+combatPvp:setArea(createCombatArea(AREA_WALLFIELD_ENERGY, AREADIAGONAL_WALLFIELD_ENERGY))
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGYBALL)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_NOPVP)
+combatNoPvp:setArea(createCombatArea(AREA_WALLFIELD_ENERGY, AREADIAGONAL_WALLFIELD_ENERGY))
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(33)
@@ -18,7 +36,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_ENERGY_WALL_RUNE)
 rune:runeId(3166)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(4)
 rune:level(41)
 rune:magicLevel(9)

--- a/data/scripts/runes/energy_wall.lua
+++ b/data/scripts/runes/energy_wall.lua
@@ -24,7 +24,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/energy_wall.lua
+++ b/data/scripts/runes/energy_wall.lua
@@ -15,19 +15,19 @@ combatNoPvp:setArea(createCombatArea(AREA_WALLFIELD_ENERGY, AREADIAGONAL_WALLFIE
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(33)

--- a/data/scripts/runes/fire_bomb.lua
+++ b/data/scripts/runes/fire_bomb.lua
@@ -24,7 +24,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/fire_bomb.lua
+++ b/data/scripts/runes/fire_bomb.lua
@@ -1,14 +1,32 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL)
-combat:setArea(createCombatArea(AREA_SQUARE1X1))
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL)
+combatPvp:setArea(createCombatArea(AREA_SQUARE1X1))
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_NOPVP)
+combatNoPvp:setArea(createCombatArea(AREA_SQUARE1X1))
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(17)
@@ -18,7 +36,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_FIRE_BOMB_RUNE)
 rune:runeId(3192)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(2)
 rune:level(27)
 rune:magicLevel(5)

--- a/data/scripts/runes/fire_bomb.lua
+++ b/data/scripts/runes/fire_bomb.lua
@@ -15,19 +15,19 @@ combatNoPvp:setArea(createCombatArea(AREA_SQUARE1X1))
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(17)

--- a/data/scripts/runes/fire_field.lua
+++ b/data/scripts/runes/fire_field.lua
@@ -22,7 +22,9 @@ function rune.onCastSpell(creature, var, isHotkey)
 	    rune:setPzLocked(true)
 		return true
     else
-		combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+        return true
     end
 end
 

--- a/data/scripts/runes/fire_field.lua
+++ b/data/scripts/runes/fire_field.lua
@@ -1,13 +1,29 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL)
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL)
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_NOPVP)
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+	    rune:setPzLocked(true)
+		return true
+    else
+		combatNoPvp:execute(creature, var)
+    end
 end
 
 rune:id(25)
@@ -17,11 +33,10 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_FIRE_FIELD_RUNE)
 rune:runeId(3188)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(3)
 rune:level(15)
 rune:magicLevel(1)
 rune:cooldown(2 * 1000)
 rune:groupCooldown(2 * 1000)
-rune:isBlocking(true) -- True = Solid / False = Creature
+rune:isBlocking(true)
 rune:register()

--- a/data/scripts/runes/fire_field.lua
+++ b/data/scripts/runes/fire_field.lua
@@ -13,19 +13,19 @@ combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_NOPVP)
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-	    rune:setPzLocked(true)
-		return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(25)

--- a/data/scripts/runes/fire_wall.lua
+++ b/data/scripts/runes/fire_wall.lua
@@ -24,7 +24,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/fire_wall.lua
+++ b/data/scripts/runes/fire_wall.lua
@@ -1,14 +1,32 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL)
-combat:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL)
+combatPvp:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_NOPVP)
+combatNoPvp:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(28)
@@ -18,7 +36,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_FIRE_WALL_RUNE)
 rune:runeId(3190)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(4)
 rune:level(33)
 rune:magicLevel(6)

--- a/data/scripts/runes/fire_wall.lua
+++ b/data/scripts/runes/fire_wall.lua
@@ -15,19 +15,19 @@ combatNoPvp:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(28)

--- a/data/scripts/runes/poison_bomb.lua
+++ b/data/scripts/runes/poison_bomb.lua
@@ -24,7 +24,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/poison_bomb.lua
+++ b/data/scripts/runes/poison_bomb.lua
@@ -15,19 +15,19 @@ combatNoPvp:setArea(createCombatArea(AREA_SQUARE1X1))
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(91)

--- a/data/scripts/runes/poison_bomb.lua
+++ b/data/scripts/runes/poison_bomb.lua
@@ -1,14 +1,32 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_PVP)
-combat:setArea(createCombatArea(AREA_SQUARE1X1))
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_PVP)
+combatPvp:setArea(createCombatArea(AREA_SQUARE1X1))
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_NOPVP)
+combatNoPvp:setArea(createCombatArea(AREA_SQUARE1X1))
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(91)
@@ -18,7 +36,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_POISON_BOMB_RUNE)
 rune:runeId(3173)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(2)
 rune:level(25)
 rune:magicLevel(4)

--- a/data/scripts/runes/poison_field.lua
+++ b/data/scripts/runes/poison_field.lua
@@ -1,13 +1,30 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_PVP)
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_PVP)
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_NOPVP)
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(26)
@@ -17,7 +34,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_POISON_FIELD_RUNE)
 rune:runeId(3172)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(3)
 rune:level(14)
 rune:magicLevel(0)

--- a/data/scripts/runes/poison_field.lua
+++ b/data/scripts/runes/poison_field.lua
@@ -13,19 +13,19 @@ combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_NOPVP)
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(26)

--- a/data/scripts/runes/poison_field.lua
+++ b/data/scripts/runes/poison_field.lua
@@ -22,7 +22,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/poison_wall.lua
+++ b/data/scripts/runes/poison_wall.lua
@@ -24,7 +24,8 @@ function rune.onCastSpell(creature, var, isHotkey)
         rune:setPzLocked(true)
         return true
     else
-        combatNoPvp:execute(creature, var)
+        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
         return true
     end
 end

--- a/data/scripts/runes/poison_wall.lua
+++ b/data/scripts/runes/poison_wall.lua
@@ -15,19 +15,19 @@ combatNoPvp:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-    if not creature:isPlayer() then
-        return false
-    end
+	if not creature:isPlayer() then
+		return false
+	end
 
-    if creature:isPzLocked() then
-        combatPvp:execute(creature, var)
-        rune:setPzLocked(true)
-        return true
-    else
-        --combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+	if creature:isPzLocked() then
 		combatPvp:execute(creature, var)
-        return true
-    end
+		rune:setPzLocked(true)
+		return true
+	else
+		--combatNoPvp:execute(creature, var) -- monsters ignore non-pvp fields for some unknown reason, enable at your own risk
+		combatPvp:execute(creature, var)
+		return true
+	end
 end
 
 rune:id(32)

--- a/data/scripts/runes/poison_wall.lua
+++ b/data/scripts/runes/poison_wall.lua
@@ -1,14 +1,32 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
-combat:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_PVP)
-combat:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
+local combatPvp = Combat()
+combatPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
+combatPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
+combatPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
+combatPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_PVP)
+combatPvp:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
+
+local combatNoPvp = Combat()
+combatNoPvp:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
+combatNoPvp:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_RINGS)
+combatNoPvp:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
+combatNoPvp:setParameter(COMBAT_PARAM_CREATEITEM, ITEM_POISONFIELD_NOPVP)
+combatNoPvp:setArea(createCombatArea(AREA_WALLFIELD, AREADIAGONAL_WALLFIELD))
 
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, var, isHotkey)
-	return combat:execute(creature, var)
+    if not creature:isPlayer() then
+        return false
+    end
+
+    if creature:isPzLocked() then
+        combatPvp:execute(creature, var)
+        rune:setPzLocked(true)
+        return true
+    else
+        combatNoPvp:execute(creature, var)
+        return true
+    end
 end
 
 rune:id(32)
@@ -18,7 +36,6 @@ rune:castSound(SOUND_EFFECT_TYPE_SPELL_OR_RUNE)
 rune:impactSound(SOUND_EFFECT_TYPE_SPELL_POISON_WALL_RUNE)
 rune:runeId(3176)
 rune:allowFarUse(true)
-rune:setPzLocked(true)
 rune:charges(4)
 rune:level(29)
 rune:magicLevel(5)


### PR DESCRIPTION
1.- NonPVP fields won't damage players.
2.- If a player is pzlocked he will create PVP Fields using runes, if not then the regular rune to hunt is created.
3.- Players no longer get pzlocked when using runes for no reason.
4.- Fixed Items.xml damage in noPVP fields that override any lua condition or damage.
5.- Avoided blackskull trap bug by checking player status before creating a rune.
6.- Avoided use of skull check because idle skulled players may cause indirect damage unintentionaly.
Enjoy!