### PR TITLE
fix: storage nill crash

### DIFF
--- a/data-global/scripts/actions/other/others/quest_system2.lua
+++ b/data-global/scripts/actions/other/others/quest_system2.lua
@@ -359,17 +359,16 @@ that is was torn by a big paw ...]],
 local questSystem2 = Action()
 
 function questSystem2.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	local useItem = config[item.uid]
+	if not useItem then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "This item is not properly configured. Missing UID entry.")
+		return true
+	end
 
-    local useItem = config[item.uid]
-    if not useItem then
-        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "This item is not properly configured. Missing UID entry.")
-        return true
-    end
-
-    if not useItem.storage then
-        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Missing storage key value. Please contact a gamemaster.")
-        return true
-    end
+	if not useItem.storage then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Missing storage key value. Please contact a gamemaster.")
+		return true
+	end
 
 	local useItem = config[item.uid]
 	if not useItem then

--- a/data-global/scripts/quests/the_rookie_guard/mission06_run_like_wolf.lua
+++ b/data-global/scripts/quests/the_rookie_guard/mission06_run_like_wolf.lua
@@ -135,34 +135,33 @@ warWolfDenTiles:register()
 -- War wolf den boost tiles
 
 local function teleportBack(uid)
-    local player = Player(uid)
-    if player and player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06) == 5 then
-        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Oh no... you were too slow and the wolves caught up with you. You may try again.")
-        player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06, 4)
-        player:teleportTo({ x = 32109, y = 32131, z = 11 })
-    end
+	local player = Player(uid)
+	if player and player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06) == 5 then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Oh no... you were too slow and the wolves caught up with you. You may try again.")
+		player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06, 4)
+		player:teleportTo({ x = 32109, y = 32131, z = 11 })
+	end
 end
 
 local warWolfDenBoostTiles = MoveEvent()
 
 function warWolfDenBoostTiles.onStepIn(creature, item, position, fromPosition)
-    local player = creature:getPlayer()
-    if not player then
-        return true
-    end
-    local missionState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06)
-    if missionState == 4 then
-        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "RUUUUUUUUUUUUUUUUUN!")
-        player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06, 5)
-        player:getPosition():sendMagicEffect(CONST_ME_POFF)
-        local condition = Condition(CONDITION_HASTE)
-        condition:setTicks(25000)
-        condition:setParameter(CONDITION_PARAM_SPEED, 300)
-        player:addCondition(condition)
-        
-        addEvent(teleportBack, 60000, player:getId())
-    end
-    return true
+	local player = creature:getPlayer()
+	if not player then
+		return true
+	end
+	local missionState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06)
+	if missionState == 4 then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "RUUUUUUUUUUUUUUUUUN!")
+		player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06, 5)
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		local conditionHaste = Condition(CONDITION_HASTE)
+		conditionHaste:setParameter(CONDITION_PARAM_TICKS, 25000)
+		conditionHaste:setFormula(0.3, -24, 0.3, -24)
+		player:addCondition(conditionHaste)
+		addEvent(teleportBack, 25000, player:getId())
+	end
+	return true
 end
 
 warWolfDenBoostTiles:aid(50334)
@@ -174,16 +173,16 @@ local poacherCorpse = Action()
 
 function poacherCorpse.onUse(player, item, frompos, itemEx, topos)
 	local missionState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06)
-		local corpseState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.PoacherCorpse)
-		if corpseState == -1 then
-			local reward = Game.createItem(12672, 1)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have found " .. reward:getArticle() .. " " .. reward:getName() .. ".")
-			player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.PoacherCorpse, 1)
-			player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06, 3)
-			player:addItemEx(reward, true, CONST_SLOT_WHEREEVER)
-		else
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The " .. item:getName() .. " is empty.")
-		end
+	local corpseState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.PoacherCorpse)
+	if corpseState == -1 then
+		local reward = Game.createItem(12672, 1)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have found " .. reward:getArticle() .. " " .. reward:getName() .. ".")
+		player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.PoacherCorpse, 1)
+		player:setStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06, 3)
+		player:addItemEx(reward, true, CONST_SLOT_WHEREEVER)
+	else
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The " .. item:getName() .. " is empty.")
+	end
 	return true
 end
 


### PR DESCRIPTION
I got a crash today related to this. What I do in this code? Well, simply check if there's missing uid or storage to prevent Stack Trace: Storage key is nill error. Insthead will return true and warn the player about it.