### PR TITLE
fix: possible null pinters in replaceThing

### DIFF
--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -770,8 +770,16 @@ void Container::updateThing(const std::shared_ptr<Thing> &thing, uint16_t itemId
 }
 
 void Container::replaceThing(uint32_t index, const std::shared_ptr<Thing> &thing) {
+	if (!thing) {
+		return;
+	}
+
 	const auto &item = thing->getItem();
 	if (!item) {
+		return /*RETURNVALUE_NOTPOSSIBLE*/;
+	}
+
+	if (index >= itemlist.size()) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 


### PR DESCRIPTION
- Implemented validations to confirm that the 'thing' pointer is not null and that the index is within the valid range of 'itemlist' before executing logic in `Container::replaceThing`. This helps avoid possible crashes or unpredictable behavior caused by invalid inputs.