### PR TITLE
fix: market sell item bug

### DIFF
--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -171,6 +171,8 @@ public:
 
 	std::shared_ptr<Player> getPlayerByID(uint32_t id, bool allowOffline = false);
 
+	std::shared_ptr<Player> getMarketPlayerByGUID(uint32_t &guid);
+
 	std::shared_ptr<Player> getPlayerByName(const std::string &s, bool allowOffline = false, bool isNewName = false);
 
 	std::shared_ptr<Player> getPlayerByGUID(const uint32_t &guid, bool allowOffline = false);


### PR DESCRIPTION
This PR fixes a bug with Market where:

Player 1 creates an offer for an item and goes hunting.
Player 2 goes to the Market to look for something to buy.
Player 1 dies and stays dead on the game's death screen.
Player 2 buys the item that Player 1 had put up for sale. Player 1 logs in after Player 2 buys the item.

Player 2 received the item they bought that belonged to Player 1 in the Market. 
Player 1 did not receive the money for the item they sold to Player 2.

Thanks to @feliphechaves