### PR TITLE
fix: pass party leadership if a player is kicked for lag.

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2250,6 +2250,11 @@ void Player::sendPing() {
 
 	if (noPongTime >= 60000 && canLogout() && g_creatureEvents().playerLogout(static_self_cast<Player>())) {
 		g_logger().info("Player {} has been kicked due to ping timeout. (has client: {})", getName(), client != nullptr);
+		// Try to pass party leadership before logging out
+		if (m_party) {
+			m_party->leaveParty(getPlayer(), true);
+		}
+
 		if (client) {
 			client->logout(true, true);
 		} else {


### PR DESCRIPTION
This PR attempts to fix a potential bug in the party system where a player is kicked for lag, and the party does not assign a new leader.