### PR TITLE
Improve: loot message suffix concatenation logic

### DIFF
--- a/data/scripts/eventcallbacks/monster/ondroploot__base.lua
+++ b/data/scripts/eventcallbacks/monster/ondroploot__base.lua
@@ -28,7 +28,17 @@ function callback.monsterOnDropLoot(monster, corpse)
 			msgSuffix = msgSuffix .. (string.len(msgSuffix) > 0 and ", gut charm" or "gut charm")
 		end
 	end
-	corpse:setAttribute(ITEM_ATTRIBUTE_LOOTMESSAGE_SUFFIX, existingSuffix .. msgSuffix)
+
+	local finalSuffix = ""
+	if string.len(existingSuffix) > 0 and string.len(msgSuffix) > 0 then
+		finalSuffix = existingSuffix .. " + " .. msgSuffix
+	elseif string.len(msgSuffix) > 0 then
+		finalSuffix = msgSuffix
+	else
+		finalSuffix = existingSuffix
+	end
+
+	corpse:setAttribute(ITEM_ATTRIBUTE_LOOTMESSAGE_SUFFIX, finalSuffix)
 end
 
 callback:register()


### PR DESCRIPTION
Refactored the logic for combining existing and new loot message suffixes to ensure proper formatting and avoid unintended concatenation. The new approach adds a separator only when both suffixes are present.

<img width="552" height="31" alt="image" src="https://github.com/user-attachments/assets/1dad839d-675a-4834-b6ab-92705da70ea1" />
