### PR TITLE
fix: update imbuement slots for Sanguine Claws and Grand Sanguine Claws

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -83236,7 +83236,7 @@ Granted by TibiaGoals.com" />
 		<attribute key="defense" value="21" />
 		<attribute key="skillfist" value="5" />
 		<attribute key="weight" value="7100" />
-		<attribute key="imbuementslot" value="2">
+		<attribute key="imbuementslot" value="3">
 			<attribute key="life leech" value="3" />
 			<attribute key="mana leech" value="3" />
 			<attribute key="critical hit" value="3" />
@@ -83266,7 +83266,7 @@ Granted by TibiaGoals.com" />
 		<attribute key="magiclevelpoints" value="2" />
 		<attribute key="skillfist" value="5" />
 		<attribute key="weight" value="6900" />
-		<attribute key="imbuementslot" value="2">
+		<attribute key="imbuementslot" value="3">
 			<attribute key="life leech" value="3" />
 			<attribute key="mana leech" value="3" />
 			<attribute key="critical hit" value="3" />


### PR DESCRIPTION
This pull request updates the <imbuementslot> attribute from 2 to 3 for both Sanguine Claws and Grand Sanguine Claws items.

- Ensures these items are now compatible with 3 imbuements, matching current server mechanics.
- Reflects the official item capabilities and improves consistency in item configuration files.