### PR TITLE
fix: add loot bag to mini bosses rotten blood

### DIFF
--- a/data-crystal/monster/bosses/chagorz.lua
+++ b/data-crystal/monster/bosses/chagorz.lua
@@ -91,6 +91,7 @@ monster.loot = {
 	{ name = "green gem", chance = 8348, maxCount = 1 },
 	{ name = "ultimate spirit potion", chance = 10934, maxCount = 18 },
 	{ name = "white gem", chance = 9600, maxCount = 3 },
+	{ id = 43895, chance = 360 }, -- Bag you covet
 }
 
 monster.attacks = {

--- a/data-crystal/monster/bosses/murcion.lua
+++ b/data-crystal/monster/bosses/murcion.lua
@@ -84,6 +84,7 @@ monster.loot = {
 	{ name = "supreme health potion", chance = 6212, maxCount = 102 },
 	{ name = "ultimate mana potion", chance = 8785, maxCount = 29 },
 	{ name = "ultimate spirit potion", chance = 8783, maxCount = 161 },
+	{ id = 43895, chance = 360 }, -- Bag you covet
 }
 
 monster.attacks = {

--- a/data-crystal/monster/bosses/vemiath.lua
+++ b/data-crystal/monster/bosses/vemiath.lua
@@ -95,6 +95,7 @@ monster.loot = {
 	{ name = "raw watermelon tourmaline", chance = 9302, maxCount = 1 },
 	{ name = "vemiath's infused basalt", chance = 7914, maxCount = 1 },
 	{ name = "violet gem", chance = 7210, maxCount = 1 },
+	{ id = 43895, chance = 360 }, -- Bag you covet
 }
 
 monster.attacks = {

--- a/data-global/monster/bosses/chagorz.lua
+++ b/data-global/monster/bosses/chagorz.lua
@@ -98,6 +98,7 @@ monster.loot = {
 	{ name = "raw watermelon tourmaline", chance = 1050, maxCount = 1 },
 	{ name = "the essence of chagorz", chance = 1050, maxCount = 1 },
 	{ name = "unicorn figurine", chance = 500 },
+	{ id = 43895, chance = 360 }, -- Bag you covet
 }
 
 monster.attacks = {

--- a/data-global/monster/bosses/murcion.lua
+++ b/data-global/monster/bosses/murcion.lua
@@ -86,6 +86,7 @@ monster.loot = {
 	{ name = "supreme health potion", chance = 6212, maxCount = 102 },
 	{ name = "ultimate mana potion", chance = 8785, maxCount = 29 },
 	{ name = "ultimate spirit potion", chance = 8783, maxCount = 161 },
+	{ id = 43895, chance = 360 }, -- Bag you covet
 }
 
 monster.attacks = {

--- a/data-global/monster/bosses/vemiath.lua
+++ b/data-global/monster/bosses/vemiath.lua
@@ -97,6 +97,7 @@ monster.loot = {
 	{ name = "raw watermelon tourmaline", chance = 9302, maxCount = 1 },
 	{ name = "vemiath's infused basalt", chance = 7914, maxCount = 1 },
 	{ name = "violet gem", chance = 7210, maxCount = 1 },
+	{ id = 43895, chance = 360 }, -- Bag you covet
 }
 
 monster.attacks = {


### PR DESCRIPTION
Adds bag loot to the other three mini bosses ichgahal, vemiath, and chagorz.