### PR TITLE
fix: resolve equipment slot conflicts for bow, quiver, and shield

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3454,7 +3454,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 
 	if (player->hasCondition(CONDITION_FEARED)) {
 		/*
-		 *	When player is feared the player can´t equip any items.
+		 *  When player is feared the player can´t equip any items.
 		 */
 		player->sendTextMessage(MESSAGE_FAILURE, "You are feared.");
 		return;
@@ -3497,17 +3497,19 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 
 			const int32_t &slotPosition = equipItem->getSlotPosition();
 
-			// Checks if a two-handed item is being equipped in the left slot when the right slot is already occupied and move to backpack
-			/* BUT allows quiver to be equipped when a distance weapon (bow) is in the left hand */
-			if (
-				(slotPosition & SLOTP_LEFT)
-				&& (slotPosition & SLOTP_TWO_HAND)
-				&& rightItem
-				&& !(it.weaponType == WEAPON_DISTANCE)
-				&& !rightItem->isQuiver()
-				&& (!leftItem || leftItem->getWeaponType() != WEAPON_DISTANCE)
-				&& !it.isQuiver() /* Allows equipping quiver even with item in right slot */
-			) {
+			/* Check if trying to equip a two-handed weapon when shield or other item is equipped */
+			if (slot == CONST_SLOT_LEFT && (slotPosition & SLOTP_TWO_HAND) && rightItem && !rightItem->isQuiver()) {
+				// Remove the shield/item from right slot to make room for two-handed weapon
+				ret = internalCollectManagedItems(player, rightItem, getObjectCategory(rightItem), false);
+				if (ret != RETURNVALUE_NOERROR) {
+					player->sendCancelMessage(ret);
+					return;
+				}
+			}
+
+			/* Checks if a two-handed item is being equipped in the left slot when the right slot is already occupied
+			BUT allows quiver to be equipped when a distance weapon (bow) is in the left hand */
+			if ((slotPosition & SLOTP_LEFT) && (slotPosition & SLOTP_TWO_HAND) && rightItem && !rightItem->isQuiver() && !it.isQuiver()) {
 				ret = internalCollectManagedItems(player, rightItem, getObjectCategory(rightItem), false);
 			}
 
@@ -3525,7 +3527,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 				// Check if trying to equip a shield while a two-handed weapon is equipped in the left slot
 				if (slot == CONST_SLOT_RIGHT && leftItem && leftItem->getSlotPosition() & SLOTP_TWO_HAND) {
 					// Don't unequip distance bow when equipping quiver
-					if (!it.isQuiver() || leftItem->getWeaponType() != WEAPON_DISTANCE) {
+					if (!it.isQuiver()) {
 						// Unequip the two-handed weapon from the left slot
 						ret = internalMoveItem(leftItem->getParent(), player, INDEX_WHEREEVER, leftItem, leftItem->getItemCount(), nullptr);
 						if (ret == RETURNVALUE_NOERROR) {


### PR DESCRIPTION
This PR fixes multiple equipment slot conflicts in the two-handed weapon system involving bows, quivers, and shields. The previous logic was preventing proper equipment switching between these item types.

---

## Problems Fixed

### Problem 1: Quiver cannot be equipped with bow
When a player had a bow equipped in the left hand and tried to equip a quiver:
- The bow was being removed from the left slot
- The quiver was NOT being equipped in the right slot
- Player was left with no weapon equipped

### Problem 2: Shield cannot be equipped after bow + quiver
When a player had both bow and quiver equipped and tried to equip a shield:
- The shield would not equip
- Both bow and quiver remained equipped, blocking the shield slot

### Problem 3: Bow cannot be equipped when shield is equipped
When a player had a shield equipped in the right slot and tried to equip a two-handed bow:
- The bow would not equip
- The shield remained in the right slot, preventing the bow from equipping

---

## Solution

Modified `Game::playerEquipItem()` to handle slot conflicts properly:

1. **Added quiver-specific logic** (Lines 3500-3512)
   - Allow quiver to be equipped even when right slot has items
   - Prevent removing items when equipping quiver with distance weapon
   - Check for `!it.isQuiver()` to exclude quivers from slot clearing

2. **Added two-handed weapon validation** (Lines 3500-3508)
   - Check if equipping two-handed weapon when shield is in right slot
   - Remove shield/item to make room for two-handed weapon
   - Preserve quiver when equipping bow (don't remove it)

3. **Fixed shield equipment logic** (Lines 3528-3530)
   - Simplified condition to allow shields to properly unequip bows
   - Only prevent unequipping when item being equipped is a quiver
   - Removed overly protective logic that blocked legitimate equipment changes

---

## Testing

All scenarios tested and working correctly:

- ✅ Equip bow in left hand → Equip quiver in right hand → Both remain equipped
- ✅ Equip quiver → Equip another quiver → Old quiver is replaced correctly
- ✅ Equip bow + quiver → Equip shield → Bow is unequipped, shield equips
- ✅ Equip shield → Equip bow → Shield is unequipped, bow equips
- ✅ Equip two-handed melee weapon → Equip shield → Weapon is unequipped (expected)
- ✅ Arrows inside quiver are consumed correctly during combat

---
**Before:**

##  Changes Made

**File:** `src/game/game.cpp`

**Function:** `Game::playerEquipItem()`

**Lines Modified:** ~3509, ~3528

---

**After:**
## Changes Made

**File:** `src/game/game.cpp`

**Function:** `Game::playerEquipItem()`

**Lines Modified:** 3500-3512, 3528-3530

---

## Code Review Notes

- All changes maintain backward compatibility
- No breaking changes to existing equipment behavior
- Logic is now more explicit and easier to maintain
- Comments added to explain the quiver exception handling

## Reviewers

@jprzimba
