### PR TITLE
fix food item ID in talkaction script

### DIFF
--- a/data/scripts/talkactions/player/food.lua
+++ b/data/scripts/talkactions/player/food.lua
@@ -2,7 +2,7 @@ local food = TalkAction("!food")
 
 local config = {
 	price = 1000,
-	itemId = 3731,
+	itemId = 3725, --Brown Mushroom
 	quantity = 100,
 }
 


### PR DESCRIPTION
Changed the food item ID from 3731 (Fire Mushroom) to 3725 (Brown Mushroom) in the player food talk action script to correct the item being given, the players could sell the 100 fire mushrooms to the NPC Luna for $20k.