### PR TITLE
fix: lastLogout update

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -4186,6 +4186,7 @@ void Player::death(const std::shared_ptr<Creature> &lastHitCreature) {
 		sendSkills();
 		sendReLoginWindow(unfairFightReduction);
 		sendBlessStatus();
+		lastLogout = getTimeNow();
 		if (getSkull() == SKULL_BLACK) {
 			health = g_configManager().getNumber(BLACK_SKULL_DEATH_HEALTH);
 			mana = g_configManager().getNumber(BLACK_SKULL_DEATH_MANA);


### PR DESCRIPTION
This change introduces a small but significant update to the Player::death method in player.cpp. Now, when a player dies, the lastLogout timestamp is updated to the current time, ensuring that the player's last logout time is accurately recorded upon death.