### PR TITLE
fix: standardize all norcferatu augments formatting

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -3802,7 +3802,7 @@
 		<attribute key="primarytype" value="windows" />
 	</item>
 	<item id="1748" article="a" name="mast">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="1749" toid="1750" article="a" name="sail" />
 	<item fromid="1751" toid="1754" article="a" name="rudder of the boat" />
@@ -3828,7 +3828,7 @@
 		<attribute key="primarytype" value="tools (objects)" />
 	</item>
 	<item fromid="1769" toid="1770" article="a" name="mast">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="1771" article="a" name="drawbridge">
 		<attribute key="primarytype" value="artificial tiles" />
@@ -4480,10 +4480,10 @@
 	<item id="2150" name="RESERVED SPRITE" />
 	<item id="2151" name="RESERVED SPRITE" />
 	<item id="2152" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2153" article="a" name="marble pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="2154" toid="2161" article="a" name="wooden railing">
 		<attribute key="primarytype" value="walls" />
@@ -4524,13 +4524,13 @@
 		<attribute key="primarytype" value="artificial tiles" />
 	</item>
 	<item id="2188" article="a" name="sandstone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2189" article="a" name="sandstone statue">
 		<attribute key="primarytype" value="statues" />
 	</item>
 	<item id="2190" article="an" name="oriental pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2191" article="a" name="ramp" />
 	<item id="2192" article="a" name="ramp">
@@ -4549,7 +4549,7 @@
 		<attribute key="floorchange" value="west" />
 	</item>
 	<item id="2199" article="an" name="obelisk">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2200" article="a" name="broken obelisk">
 		<attribute key="primarytype" value="refuse" />
@@ -4576,11 +4576,11 @@
 	</item>
 	<item fromid="2253" toid="2254" article="a" name="rope bridge" />
 	<item fromid="2255" toid="2258" article="a" name="short pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="2259" toid="2262" article="a" name="rope bridge" />
 	<item id="2263" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2264" article="a" name="broken stone pillar">
 		<attribute key="primarytype" value="refuse" />
@@ -4589,7 +4589,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item id="2289" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2290" article="a" name="broken stone pillar">
 		<attribute key="primarytype" value="refuse" />
@@ -4605,11 +4605,11 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item id="2299" article="a" name="small totem pole">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="2300" article="a" name="large totem pole" />
 	<item id="2301" article="a" name="totem pole">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="2302" toid="2314" article="a" name="big table">
 		<attribute key="primarytype" value="furniture" />
@@ -14256,7 +14256,7 @@
 	</item>
 	<item fromid="4920" toid="4939" article="a" name="ship railing" />
 	<item fromid="4940" toid="4952" article="a" name="mast">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="4953" toid="4960" article="a" name="sail" />
 	<item fromid="4961" toid="4964" article="a" name="steering wheel">
@@ -14275,7 +14275,7 @@
 		<attribute key="primarytype" value="utilities" />
 	</item>
 	<item fromid="4974" toid="4975" article="a" name="mast">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="4976" article="an" name="anchor">
 		<attribute key="primarytype" value="utilities" />
@@ -14359,10 +14359,10 @@
 		<attribute key="weight" value="2200" />
 	</item>
 	<item id="5025" article="an" name="iron pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="5026" article="an" name="iron construction">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="5027" article="a" name="thread of screw" />
 	<item fromid="5028" toid="5030" article="a" name="screw">
@@ -14808,7 +14808,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item id="5307" article="a" name="white stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="5308" toid="5313" article="a" name="white stone railing">
 		<attribute key="primarytype" value="walls" />
@@ -14817,7 +14817,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item fromid="5320" toid="5330" article="a" name="wooden column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="5331" toid="5388" article="a" name="sign">
 		<attribute key="primarytype" value="signs" />
@@ -15036,7 +15036,7 @@
 		<attribute key="maletransformto" value="5496" />
 	</item>
 	<item id="5503" article="a" name="wooden column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="5504" toid="5511" article="a" name="pulley">
 		<attribute key="primarytype" value="machines (objects)" />
@@ -18392,7 +18392,7 @@
 		<attribute key="primarytype" value="constructions" />
 	</item>
 	<item fromid="6886" toid="6888" article="a" name="strut">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="6889" toid="6890" name="tusks" />
 	<item id="6891" article="a" name="closed door" editorsuffix="(it is locked)">
@@ -18495,10 +18495,10 @@
 		<attribute key="primarytype" value="remains" />
 	</item>
 	<item id="6972" article="a" name="bone totem">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="6973" article="a" name="mammoth totem">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="6974" toid="6977" article="a" name="mammoth skull">
 		<attribute key="primarytype" value="remains" />
@@ -18636,10 +18636,10 @@
 		<attribute key="type" value="door" />
 	</item>
 	<item id="7058" article="a" name="skull pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="7059" article="a" name="glowing skull pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="7060" toid="7061" name="ice" />
 	<item fromid="7062" toid="7074" name="rock">
@@ -20810,7 +20810,7 @@
 	<item fromid="7696" toid="7703" article="a" name="gem" />
 	<item fromid="7704" toid="7707" article="a" name="buttress" />
 	<item fromid="7708" toid="7710" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="7711" article="a" name="closed door" editorsuffix="(it is locked)">
 		<attribute key="type" value="door" />
@@ -21026,10 +21026,10 @@
 		<attribute key="primarytype" value="flags" />
 	</item>
 	<item id="7795" article="an" name="orcish totem pole">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="7796" article="an" name="orcish pole">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="7797" toid="7798" article="a" name="dwarven statue" />
 	<item fromid="7799" toid="7802" article="a" name="bone">
@@ -23021,7 +23021,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item id="8388" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="8389" name="broken stone pillar">
 		<attribute key="primarytype" value="refuse" />
@@ -23074,7 +23074,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item fromid="8477" toid="8488" article="a" name="small tower">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="8489" toid="8498" article="a" name="stone wall">
 		<attribute key="primarytype" value="walls" />
@@ -23103,7 +23103,7 @@
 		<attribute key="primarytype" value="illumination" />
 	</item>
 	<item id="8525" article="a" name="blood basin">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="8526" article="a" name="family banner">
 		<attribute key="primarytype" value="flags" />
@@ -23254,7 +23254,7 @@
 		<attribute key="containersize" value="10" />
 	</item>
 	<item id="8739" article="a" name="wooden pole">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="8740" toid="8741" article="a" name="wall mirror">
 		<attribute key="primarytype" value="wall hangings" />
@@ -23519,7 +23519,7 @@
 		</attribute>
 	</item>
 	<item id="8865" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="8866" article="a" name="dead unknown">
 		<attribute key="fluidsource" value="blood" />
@@ -23549,7 +23549,7 @@
 		<attribute key="weight" value="120000" />
 	</item>
 	<item fromid="8870" toid="8877" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="8878" toid="8885" name="earth" />
 	<item id="8886" article="an" name="iron floor">
@@ -24410,42 +24410,42 @@
 	</item>
 	<item id="9132" article="a" name="frost cannon" />
 	<item id="9133" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9137" />
 	</item>
 	<item id="9134" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9138" />
 	</item>
 	<item id="9135" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9139" />
 	</item>
 	<item id="9136" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9140" />
 	</item>
 	<item id="9137" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9133" />
 	</item>
 	<item id="9138" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9134" />
 	</item>
 	<item id="9139" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9135" />
 	</item>
 	<item id="9140" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 		<attribute key="duration" value="10" />
 		<attribute key="decayTo" value="9136" />
 	</item>
@@ -24959,7 +24959,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item fromid="9280" toid="9285" article="a" name="limestone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="9286" toid="9289" article="a" name="limestone wall">
 		<attribute key="primarytype" value="walls" />
@@ -27737,11 +27737,11 @@
 		<attribute key="primarytype" value="natural tiles" />
 	</item>
 	<item fromid="10837" toid="10839" article="a" name="skull pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="10840" article="a" name="dimensional portal" />
 	<item id="10841" article="a" name="skull pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="10842" article="a" name="dimensional portal" />
 	<item id="10846" article="a" name="stone wall">
@@ -27776,7 +27776,7 @@
 	<item fromid="10967" toid="10968" article="a" name="decorative shield" />
 	<item fromid="10975" toid="10976" article="a" name="statue" />
 	<item id="10977" article="a" name="sapphire stand">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="10978" toid="10979" article="a" name="chair" />
 	<item id="10980" article="a" name="blood crask" />
@@ -29295,7 +29295,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item fromid="11861" toid="11869" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="11870" toid="11882" article="a" name="stone wall">
 		<attribute key="primarytype" value="walls" />
@@ -30083,7 +30083,7 @@
 		<attribute key="primarytype" value="shrines and altars" />
 	</item>
 	<item id="12476" article="a" name="scorpion pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="12477" article="a" name="small golden taboret">
 		<attribute key="primarytype" value="furniture" />
@@ -31204,7 +31204,7 @@
 		<attribute key="primarytype" value="walls" />
 	</item>
 	<item fromid="13122" toid="13124" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="13125" toid="13134" article="an" name="archway">
 		<attribute key="primarytype" value="constructions" />
@@ -31240,7 +31240,7 @@
 		<attribute key="primarytype" value="constructions" />
 	</item>
 	<item fromid="13149" toid="13154" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="13155" article="a" name="large fossil volute" />
 	<item id="13156" article="a" name="small fossil volute" />
@@ -33389,7 +33389,7 @@
 		<attribute key="primarytype" value="artificial tiles" />
 	</item>
 	<item id="15611" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="15612" toid="15615" name="wooden floor">
 		<attribute key="primarytype" value="artificial tiles" />
@@ -35115,10 +35115,10 @@
 		<attribute key="primarytype" value="portals" />
 	</item>
 	<item fromid="17183" toid="17188" name="stone pillars">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="17189" toid="17194" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="17195" toid="17200" article="a" name="stone wall">
 		<attribute key="primarytype" value="walls" />
@@ -35162,7 +35162,7 @@
 		<attribute key="floorchange" value="west" />
 	</item>
 	<item id="17231" article="a" name="wooden scaffolding">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="17232" toid="17234" article="a" name="small wooden fence">
 		<attribute key="primarytype" value="walls" />
@@ -35195,10 +35195,10 @@
 	</item>
 	<item fromid="17330" toid="17335" article="an" name="ornament" />
 	<item fromid="17336" toid="17338" article="a" name="pencil tower">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="17339" article="a" name="copper roof">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="17340" article="a" name="socket" />
 	<item fromid="17341" toid="17344" article="a" name="golden statue">
@@ -36062,7 +36062,7 @@
 		<attribute key="primarytype" value="constructions" />
 	</item>
 	<item fromid="17834" toid="17835" article="a" name="copper roof">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="17836" toid="17845" name="unknown item" />
 	<item id="17846" article="a" name="leather harness">
@@ -39338,7 +39338,7 @@
 		<attribute key="description" value="This board will notify you of currently active mini world changes all over Tibia." />
 	</item>
 	<item id="19246" article="a" name="crystal column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="19247" article="a" name="glowing ice cube" />
 	<item id="19248" name="RESERVED SPRITE" />
@@ -47204,14 +47204,14 @@ hands of its owner. Granted by TibiaRoyal.com" />
 		<attribute key="primarytype" value="refuse" />
 	</item>
 	<item fromid="23991" toid="23992" article="a" name="obelisk">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="23993" toid="23996" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="23997" toid="24000" article="a" name="broken column" />
 	<item fromid="24001" toid="24012" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="24013" toid="24014" article="a" name="monument">
 		<attribute key="primarytype" value="statues" />
@@ -48669,13 +48669,13 @@ hands of its owner. Granted by TibiaRoyal.com" />
 	</item>
 	<item id="25643" article="a" name="small stones" />
 	<item fromid="25644" toid="25647" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="25648" toid="25649" article="a" name="cult object">
 		<attribute key="primarytype" value="quest objects" />
 	</item>
 	<item fromid="25650" toid="25653" article="a" name="stone pillar">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="25654" toid="25659" article="a" name="cult symbol">
 		<attribute key="primarytype" value="wall hangings" />
@@ -57542,7 +57542,7 @@ hands of its owner. Granted by TibiaRoyal.com" />
 	<item fromid="30623" toid="30624" article="a" name="reed" />
 	<item id="30625" article="a" name="granite pillar" />
 	<item fromid="30626" toid="30635" article="a" name="obelisk">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="30636" toid="30645" article="a" name="door casing" />
 	<item id="30646" article="a" name="granite pillar" />
@@ -57711,21 +57711,21 @@ hands of its owner. Granted by TibiaRoyal.com" />
 	</item>
 	<item fromid="30992" toid="31037" article="a" name="wall" />
 	<item fromid="31038" toid="31050" article="a" name="wooden scaffolding">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="31051" article="a" name="wooden planks">
 		<attribute key="primarytype" value="tools (objects)" />
 	</item>
 	<item id="31052" article="a" name="wooden scaffolding">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="31053" toid="31055" article="a" name="large canvas" />
 	<item id="31056" article="a" name="wooden scaffolding">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="31057" toid="31059" article="a" name="large canvas" />
 	<item fromid="31060" toid="31063" article="a" name="wooden scaffolding">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="31064" toid="31072" article="a" name="wooden planks">
 		<attribute key="primarytype" value="tools (objects)" />
@@ -57761,7 +57761,7 @@ hands of its owner. Granted by TibiaRoyal.com" />
 		<attribute key="type" value="ladder" />
 	</item>
 	<item fromid="31131" toid="31133" article="a" name="obelisk">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item fromid="31134" toid="31138" name="RESERVED SPRITE" />
 	<item id="31139" article="a" name="sandstone" />
@@ -67059,7 +67059,7 @@ former students at the Noodles Academy. Awarded by TibiaLabs.com" />
 		<attribute key="primarytype" value="artificial tiles" />
 	</item>
 	<item fromid="36012" toid="36018" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="36019" article="a" name="white lion doll">
 		<attribute key="primarytype" value="dolls and bears" />
@@ -67138,7 +67138,7 @@ former students at the Noodles Academy. Awarded by TibiaLabs.com" />
 		<attribute key="primarytype" value="artificial tiles" />
 	</item>
 	<item fromid="36541" toid="36542" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="36543" article="a" name="chisel">
 		<attribute key="primarytype" value="tools" />
@@ -71022,20 +71022,20 @@ Granted by TibiaGoals.com" />
 		<attribute key="primarytype" value="traps" />
 	</item>
 	<item fromid="37999" toid="38000" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="38001" article="a" name="ruined column" />
 	<item fromid="38002" toid="38003" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="38004" article="a" name="ruined column" />
 	<item fromid="38005" toid="38007" article="a" name="spire" />
 	<item fromid="38008" toid="38009" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="38010" article="a" name="ruined column" />
 	<item fromid="38011" toid="38012" article="a" name="column">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="38013" article="a" name="ruined column" />
 	<item fromid="38014" toid="38016" article="a" name="spire" />
@@ -75366,7 +75366,7 @@ Granted by TibiaGoals.com" />
 		<attribute key="duration" value="10" />
 		<attribute key="fluidSource" value="blood" />
 	</item>
-	<item id="43810" article="a" name="large seashell"/>
+	<item id="43810" article="a" name="large seashell" />
 	<item id="43811" article="a" name="large seashell">
 		<attribute key="description" value="It is empty." />
 		<attribute key="decayTo" value="43810" />
@@ -75596,8 +75596,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="weaponType" value="sword" />
 		<attribute key="attack" value="8" />
 		<attribute key="elementfire" value="46" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="300"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="300" />
 		<attribute key="extradef" value="3" />
 		<attribute key="defense" value="32" />
 		<attribute key="skillsword" value="4" />
@@ -75624,11 +75624,11 @@ Granted by TibiaGoals.com" />
 	<item id="43865" article="a" name="grand sanguine blade">
 		<attribute key="primarytype" value="sword weapons" />
 		<attribute key="weaponType" value="sword" />
-		<attribute key="slotType" value="two-handed"/>
+		<attribute key="slotType" value="two-handed" />
 		<attribute key="attack" value="8" />
 		<attribute key="elementfire" value="46" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="300"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="300" />
 		<attribute key="extradef" value="3" />
 		<attribute key="defense" value="32" />
 		<attribute key="skillsword" value="4" />
@@ -75660,8 +75660,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="weaponType" value="club" />
 		<attribute key="attack" value="8" />
 		<attribute key="elementdeath" value="46" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="300"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="300" />
 		<attribute key="extradef" value="3" />
 		<attribute key="defense" value="32" />
 		<attribute key="skillclub" value="4" />
@@ -75690,8 +75690,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="weaponType" value="club" />
 		<attribute key="attack" value="8" />
 		<attribute key="elementdeath" value="46" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="300"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="300" />
 		<attribute key="extradef" value="3" />
 		<attribute key="defense" value="32" />
 		<attribute key="skillclub" value="4" />
@@ -75720,8 +75720,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="weaponType" value="axe" />
 		<attribute key="attack" value="8" />
 		<attribute key="elementfire" value="46" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="300"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="300" />
 		<attribute key="extradef" value="3" />
 		<attribute key="defense" value="32" />
 		<attribute key="skillaxe" value="4" />
@@ -75750,8 +75750,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="weaponType" value="axe" />
 		<attribute key="attack" value="8" />
 		<attribute key="elementfire" value="46" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="300"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="300" />
 		<attribute key="extradef" value="3" />
 		<attribute key="defense" value="32" />
 		<attribute key="skillaxe" value="4" />
@@ -76108,8 +76108,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="shootType" value="energy" />
 		<attribute key="absorbpercentearth" value="7" />
 		<attribute key="magiclevelpoints" value="4" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="200"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="200" />
 		<attribute key="firemagiclevelpoints" value="1" />
 		<attribute key="energymagiclevelpoints" value="1" />
 		<attribute key="criticalhitdamage" value="500" />
@@ -76147,8 +76147,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="shootType" value="energy" />
 		<attribute key="absorbpercentearth" value="7" />
 		<attribute key="magiclevelpoints" value="4" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="200"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="200" />
 		<attribute key="firemagiclevelpoints" value="1" />
 		<attribute key="energymagiclevelpoints" value="1" />
 		<attribute key="range" value="6" />
@@ -76253,8 +76253,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="shootType" value="earth" />
 		<attribute key="absorbpercentdeath" value="7" />
 		<attribute key="magiclevelpoints" value="4" />
-		<attribute key="manaleechamount" value="100"/>
-		<attribute key="lifeleechamount" value="600"/>
+		<attribute key="manaleechamount" value="100" />
+		<attribute key="lifeleechamount" value="600" />
 		<attribute key="earthmagiclevelpoints" value="1" />
 		<attribute key="range" value="6" />
 		<attribute key="icemagiclevelpoints" value="1" />
@@ -76382,20 +76382,20 @@ Granted by TibiaGoals.com" />
 		<attribute key="decayTo" value="0" />
 		<attribute key="duration" value="5" />
 	</item>
-	<item id="44024" name="corpse" name="dead chagorz">
-        <attribute key="containersize" value="8" />
-        <attribute key="decayTo" value="44025" />
-        <attribute key="duration" value="5" />
-    </item>
-	<item id="44025" name="corpse" name="dead chagorz">
-        <attribute key="containersize" value="8" />
-        <attribute key="decayTo" value="44026" />
-        <attribute key="duration" value="5" />
-    </item>
-	<item id="44026" name="corpse" name="dead chagorz">        
-        <attribute key="decayTo" value="0" />
-        <attribute key="duration" value="5" />
-    </item>
+	<item id="44024" article="a" name="dead chagorz">
+		<attribute key="containerSize" value="8" />
+		<attribute key="decayTo" value="44025" />
+		<attribute key="duration" value="5" />
+	</item>
+	<item id="44025" article="a" name="dead chagorz">
+		<attribute key="containerSize" value="8" />
+		<attribute key="decayTo" value="44026" />
+		<attribute key="duration" value="5" />
+	</item>
+	<item id="44026" article="a" name="dead chagorz">
+		<attribute key="decayTo" value="0" />
+		<attribute key="duration" value="5" />
+	</item>
 	<item id="44021" article="a" name="dead vemiath">
 		<attribute key="containerSize" value="8" />
 		<attribute key="decayTo" value="44022" />
@@ -77291,7 +77291,7 @@ Granted by TibiaGoals.com" />
 		<attribute key="weight" value="30" />
 	</item>
 	<item id="47367" article="a" name="large obelisk">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="47368" article="an" name="amber slayer">
 		<attribute key="primarytype" value="sword weapons" />
@@ -77525,7 +77525,7 @@ Granted by TibiaGoals.com" />
 		</attribute>
 	</item>
 	<item id="47379" article="a" name="large obelisk">
-		<attribute key="primarytype" value="pillars"/>
+		<attribute key="primarytype" value="pillars" />
 	</item>
 	<item id="47381" article="an" name="orc warlord soul core">
 		<attribute key="primarytype" value="soul cores" />
@@ -81341,8 +81341,8 @@ Granted by TibiaGoals.com" />
 		<attribute key="primarytype" value="shrines and altars" />
 	</item>
 	<item id="49161" article="a" name="trapdoor">
-		<attribute key="primarytype" value="dropdowns"/>
-		<attribute key="floorchange" value="down"/>
+		<attribute key="primarytype" value="dropdowns" />
+		<attribute key="floorchange" value="down" />
 	</item>
 	<item id="49520" article="a" name="inferniarch bow">
 		<attribute key="primarytype" value="distance weapons" />
@@ -81710,56 +81710,56 @@ Granted by TibiaGoals.com" />
 		<attribute key="floorchange" value="south" />
 	</item>
 	<item id="49678" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
-		<attribute key="blockProjectile" value="1"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
+		<attribute key="blockProjectile" value="1" />
 	</item>
 	<item id="49679" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
-		<attribute key="blockProjectile" value="1"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
+		<attribute key="blockProjectile" value="1" />
 	</item>
 	<item id="49680" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
-		<attribute key="blockProjectile" value="1"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
+		<attribute key="blockProjectile" value="1" />
 	</item>
 	<item id="49681" article="a" name="closed door">
 		<attribute key="type" value="door" />
 		<attribute key="blockProjectile" value="1" />
 	</item>
 	<item id="49682" article="an" name="open gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item id="49683" article="an" name="open gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item id="49684" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item id="49685" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item id="49686" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item id="49687" article="a" name="closed gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
-		<attribute key="blockProjectile" value="1"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
+		<attribute key="blockProjectile" value="1" />
 	</item>
 	<item id="49688" article="an" name="open gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item id="49689" article="an" name="open gate">
-		<attribute key="primarytype" value="doors"/>
-		<attribute key="type" value="door"/>
+		<attribute key="primarytype" value="doors" />
+		<attribute key="type" value="door" />
 	</item>
 	<item fromid="49698" toid="49725" article="a" name="stone wall">
 		<attribute key="primarytype" value="walls" />
@@ -82975,14 +82975,14 @@ Granted by TibiaGoals.com" />
 		<attribute key="weight" value="100" />
 	</item>
 	<item id="50121" article="a" name="water trapdoor">
-		<attribute key="primarytype" value="dropdowns"/>
-		<attribute key="floorchange" value="down"/>
+		<attribute key="primarytype" value="dropdowns" />
+		<attribute key="floorchange" value="down" />
 	</item>
 	<item id="50122" article="a" name="ladder">
-		<attribute key="type" value="ladder"/>
+		<attribute key="type" value="ladder" />
 	</item>
 	<item id="50123" article="a" name="ladder">
-		<attribute key="type" value="ladder"/>
+		<attribute key="type" value="ladder" />
 	</item>
 	<item id="50124" article="a" name="arbaziloth santa">
 		<attribute key="primarytype" value="dolls and bears" />
@@ -84834,301 +84834,301 @@ Granted by TibiaGoals.com" />
 		<attribute key="wrapableto" value="23398" />
 	</item>
 	<item id="51237" article="a" name="voodoo mask">
-		<attribute key="primarytype" value="wall hangings"/>
-		<attribute key="wrapableto" value="23398"/>
+		<attribute key="primarytype" value="wall hangings" />
+		<attribute key="wrapableto" value="23398" />
 	</item>
 	<item id="51259" article="a" name="reality splinter">
-		<attribute key="description" value="Split from an alternative reality, frozen in time and space"/>
-		<attribute key="primarytype" value="quest items"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="description" value="Split from an alternative reality, frozen in time and space" />
+		<attribute key="primarytype" value="quest items" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51260" name="norcferatu skullguard">
-		<attribute key="primarytype" value="helmets"/>
-		<attribute key="armor" value="9"/>
-		<attribute key="skilldist" value="2"/>
-		<attribute key="absorbpercentphysical" value="3"/>
-		<attribute key="absorbpercentice" value="6"/>
-		<attribute key="weight" value="3200"/>
+		<attribute key="primarytype" value="helmets" />
+		<attribute key="armor" value="9" />
+		<attribute key="skilldist" value="2" />
+		<attribute key="absorbpercentphysical" value="3" />
+		<attribute key="absorbpercentice" value="6" />
+		<attribute key="weight" value="3200" />
 		<attribute key="imbuementslot" value="1">
-			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost fist" value="3"/>
+			<attribute key="mana leech" value="3" />
+			<attribute key="skillboost fist" value="3" />
 		</attribute>
 		<attribute key="augments" value="1">
 			<attribute key="ethereal spear" value="base">
-				<attribute key="value" value="4000"/>
+				<attribute key="value" value="40" />
 			</attribute>
 			<attribute key="ethereal spear" value="critical hit chance">
-				<attribute key="value" value="200"/>
+				<attribute key="value" value="200" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="head"/>
-			<attribute key="vocation" value="Paladin;true, Royal Paladin"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="head" />
+			<attribute key="vocation" value="Paladin;true, Royal Paladin" />
 		</attribute>
 	</item>
 	<item id="51261" name="norcferatu bonehood">
-		<attribute key="primarytype" value="helmets"/>
-		<attribute key="armor" value="5"/>
-		<attribute key="mantra" value="8"/>
-		<attribute key="skillfist" value="2"/>
-		<attribute key="absorbpercentphysical" value="2"/>
-		<attribute key="absorbpercentice" value="5"/>
-		<attribute key="weight" value="1400"/>
+		<attribute key="primarytype" value="helmets" />
+		<attribute key="armor" value="5" />
+		<attribute key="mantra" value="8" />
+		<attribute key="skillfist" value="2" />
+		<attribute key="absorbpercentphysical" value="2" />
+		<attribute key="absorbpercentice" value="5" />
+		<attribute key="weight" value="1400" />
 		<attribute key="imbuementslot" value="1">
-			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost fist" value="3"/>
+			<attribute key="mana leech" value="3" />
+			<attribute key="skillboost fist" value="3" />
 		</attribute>
 		<attribute key="augments" value="1">
 			<attribute key="greater tiger clash" value="base">
-				<attribute key="value" value="3300"/>
+				<attribute key="value" value="33" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="230"/>
-			<attribute key="slot" value="head"/>
-			<attribute key="vocation" value="Monk;true, Exalted Monk"/>
+			<attribute key="level" value="230" />
+			<attribute key="slot" value="head" />
+			<attribute key="vocation" value="Monk;true, Exalted Monk" />
 		</attribute>
 	</item>
 	<item id="51262" name="norcferatu tuskplate">
-		<attribute key="primarytype" value="armors"/>
-		<attribute key="armor" value="22"/>
-		<attribute key="skillsword" value="3"/>
-		<attribute key="skillclub" value="3"/>
-		<attribute key="skillaxe" value="3"/>
-		<attribute key="absorbpercentphysical" value="4"/>
-		<attribute key="weight" value="14800"/>
+		<attribute key="primarytype" value="armors" />
+		<attribute key="armor" value="22" />
+		<attribute key="skillsword" value="3" />
+		<attribute key="skillclub" value="3" />
+		<attribute key="skillaxe" value="3" />
+		<attribute key="absorbpercentphysical" value="4" />
+		<attribute key="weight" value="14800" />
 		<attribute key="augments" value="1">
 			<attribute key="brutal strike" value="cooldown">
-				<attribute key="value" value="2000"/>
+				<attribute key="value" value="2000" />
 			</attribute>
 			<attribute key="brutal strike" value="critical extra damage">
-				<attribute key="value" value="1000"/>
+				<attribute key="value" value="1000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="armor"/>
-			<attribute key="vocation" value="Knight;true, Elite Knight"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="armor" />
+			<attribute key="vocation" value="Knight;true, Elite Knight" />
 		</attribute>
 	</item>
 	<item id="51263" name="norcferatu bloodhide">
-		<attribute key="primarytype" value="armors"/>
-		<attribute key="armor" value="16"/>
-		<attribute key="energymagiclevelpoints" value="6"/>
-		<attribute key="firemagiclevelpoints" value="3"/>
-		<attribute key="absorbpercentearth" value="8"/>
-		<attribute key="weight" value="3900"/>
+		<attribute key="primarytype" value="armors" />
+		<attribute key="armor" value="16" />
+		<attribute key="energymagiclevelpoints" value="6" />
+		<attribute key="firemagiclevelpoints" value="3" />
+		<attribute key="absorbpercentearth" value="8" />
+		<attribute key="weight" value="3900" />
 		<attribute key="augments" value="1">
 			<attribute key="ultimate energy strike" value="critical extra damage">
-				<attribute key="value" value="1400"/>
+				<attribute key="value" value="1400" />
 			</attribute>
 			<attribute key="ultimate energy strike" value="critical hit chance">
-				<attribute key="value" value="500"/>
+				<attribute key="value" value="500" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="armor"/>
-			<attribute key="vocation" value="Sorcerer;true, Master Sorcerer"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="armor" />
+			<attribute key="vocation" value="Sorcerer;true, Master Sorcerer" />
 		</attribute>
 	</item>
 	<item id="51264" name="norcferatu bonecloak">
-		<attribute key="primarytype" value="armors"/>
-		<attribute key="armor" value="16"/>
-		<attribute key="earthmagiclevelpoints" value="6"/>
-		<attribute key="healingmagiclevelpoints" value="3"/>
-		<attribute key="absorbpercentice" value="8"/>
-		<attribute key="weight" value="4200"/>
+		<attribute key="primarytype" value="armors" />
+		<attribute key="armor" value="16" />
+		<attribute key="earthmagiclevelpoints" value="6" />
+		<attribute key="healingmagiclevelpoints" value="3" />
+		<attribute key="absorbpercentice" value="8" />
+		<attribute key="weight" value="4200" />
 		<attribute key="augments" value="1">
 			<attribute key="Ultimate Terra Strike" value="critical extra damage">
-				<attribute key="value" value="1400"/>
+				<attribute key="value" value="1400" />
 			</attribute>
 			<attribute key="Ultimate Terra Strike" value="critical hit chance">
-				<attribute key="value" value="500"/>
+				<attribute key="value" value="500" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="armor"/>
-			<attribute key="vocation" value="Druid;true, Elder Druid"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="armor" />
+			<attribute key="vocation" value="Druid;true, Elder Druid" />
 		</attribute>
 	</item>
 	<item id="51265" name="norcferatu thornwraps">
-		<attribute key="primarytype" value="legs"/>
-		<attribute key="armor" value="9"/>
-		<attribute key="skilldist" value="2"/>
-		<attribute key="absorbpercentphysical" value="4"/>
-		<attribute key="absorbpercentdeath" value="4"/>
-		<attribute key="weight" value="11500"/>
+		<attribute key="primarytype" value="legs" />
+		<attribute key="armor" value="9" />
+		<attribute key="skilldist" value="2" />
+		<attribute key="absorbpercentphysical" value="4" />
+		<attribute key="absorbpercentdeath" value="4" />
+		<attribute key="weight" value="11500" />
 		<attribute key="augments" value="1">
 			<attribute key="etheral spear" value="base">
-				<attribute key="value" value="4000"/>
+				<attribute key="value" value="40" />
 			</attribute>
 			<attribute key="etheral spear" value="critical extra damage">
-				<attribute key="value" value="800"/>
+				<attribute key="value" value="800" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="legs"/>
-			<attribute key="vocation" value="Paladin;true, Royal Paladin"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="legs" />
+			<attribute key="vocation" value="Paladin;true, Royal Paladin" />
 		</attribute>
 	</item>
 	<item id="51266" name="norcferatu bloodstrider">
-		<attribute key="primarytype" value="legs"/>
-		<attribute key="armor" value="8"/>
-		<attribute key="magiclevelpoints" value="2"/>
-		<attribute key="absorbpercentdeath" value="4"/>
-		<attribute key="weight" value="11500"/>
+		<attribute key="primarytype" value="legs" />
+		<attribute key="armor" value="8" />
+		<attribute key="magiclevelpoints" value="2" />
+		<attribute key="absorbpercentdeath" value="4" />
+		<attribute key="weight" value="11500" />
 		<attribute key="augments" value="1">
 			<attribute key="ultimate energy strike" value="base">
-				<attribute key="value" value="3300"/>
+				<attribute key="value" value="33" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="legs"/>
-			<attribute key="vocation" value="Druid;true, Elder Druid"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="legs" />
+			<attribute key="vocation" value="Druid;true, Elder Druid" />
 		</attribute>
 	</item>
 	<item id="51267" name="norcferatu fleshguards">
-		<attribute key="primarytype" value="legs"/>
-		<attribute key="armor" value="5"/>
-		<attribute key="mantra" value="6"/>
-		<attribute key="skillfist" value="2"/>
-		<attribute key="absorbpercentdeath" value="4"/>
-		<attribute key="weight" value="11500"/>
+		<attribute key="primarytype" value="legs" />
+		<attribute key="armor" value="5" />
+		<attribute key="mantra" value="6" />
+		<attribute key="skillfist" value="2" />
+		<attribute key="absorbpercentdeath" value="4" />
+		<attribute key="weight" value="11500" />
 		<attribute key="augments" value="1">
 			<attribute key="Greater Tiger Clash" value="critical hit chance">
-				<attribute key="value" value="250"/>
+				<attribute key="value" value="250" />
 			</attribute>
 			<attribute key="reater Tiger Clash" value="critical extra damage">
-				<attribute key="value" value="1000"/>
+				<attribute key="value" value="1000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="230"/>
-			<attribute key="slot" value="legs"/>
-			<attribute key="vocation" value="Monk;true, Exalted Monk"/>
+			<attribute key="level" value="230" />
+			<attribute key="slot" value="legs" />
+			<attribute key="vocation" value="Monk;true, Exalted Monk" />
 		</attribute>
 	</item>
 	<item id="51268" name="norcferatu goretrampers">
-		<attribute key="primarytype" value="boots"/>
-		<attribute key="absorbpercentearth" value="5"/>
-		<attribute key="absorbpercentphysical" value="5"/>
+		<attribute key="primarytype" value="boots" />
+		<attribute key="absorbpercentearth" value="5" />
+		<attribute key="absorbpercentphysical" value="5" />
 		<attribute key="imbuementslot" value="1">
-			<attribute key="increase speed" value="3"/>
+			<attribute key="increase speed" value="3" />
 		</attribute>
-		<attribute key="armor" value="3"/>
-		<attribute key="weight" value="12500"/>
+		<attribute key="armor" value="3" />
+		<attribute key="weight" value="12500" />
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="feet"/>
-			<attribute key="vocation" value="Knight;true, Elite Knight"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="feet" />
+			<attribute key="vocation" value="Knight;true, Elite Knight" />
 		</attribute>
 	</item>
 	<item id="51269" name="norcferatu fangstompers">
-		<attribute key="primarytype" value="boots"/>
-		<attribute key="armor" value="2"/>
-		<attribute key="magiclevelpoints" value="1"/>
-		<attribute key="absorbpercentdeath" value="3"/>
-		<attribute key="weight" value="11000"/>
+		<attribute key="primarytype" value="boots" />
+		<attribute key="armor" value="2" />
+		<attribute key="magiclevelpoints" value="1" />
+		<attribute key="absorbpercentdeath" value="3" />
+		<attribute key="weight" value="11000" />
 		<attribute key="augments" value="1">
 			<attribute key="ultimate energy strike" value="base">
-				<attribute key="value" value="3300"/>
+				<attribute key="value" value="33" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="level" value="270"/>
-			<attribute key="slot" value="feet"/>
-			<attribute key="vocation" value="Sorcerer;true, Master Sorcerer"/>
+			<attribute key="level" value="270" />
+			<attribute key="slot" value="feet" />
+			<attribute key="vocation" value="Sorcerer;true, Master Sorcerer" />
 		</attribute>
 	</item>
 	<item id="51270" name="ink blade">
-		<attribute key="primarytype" value="decoration"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentenergy" value="2"/>
-		<attribute key="weight" value="350"/>
+		<attribute key="primarytype" value="decoration" />
+		<attribute key="showAttributes" value="1" />
+		<attribute key="absorbpercentenergy" value="2" />
+		<attribute key="weight" value="350" />
 		<attribute key="augments" value="1">
 			<attribute key="knight familiar" value="cooldown">
 				<attribute key="value" value="300000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="slot" value="ammo"/>
-			<attribute key="vocation" value="Knight;true, Elite Knight"/>
+			<attribute key="slot" value="ammo" />
+			<attribute key="vocation" value="Knight;true, Elite Knight" />
 		</attribute>
 	</item>
 	<item id="51271" name="ink quill">
-		<attribute key="primarytype" value="decoration"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentenergy" value="2"/>
-		<attribute key="weight" value="220"/>
+		<attribute key="primarytype" value="decoration" />
+		<attribute key="showAttributes" value="1" />
+		<attribute key="absorbpercentenergy" value="2" />
+		<attribute key="weight" value="220" />
 		<attribute key="augments" value="1">
 			<attribute key="paladin familiar" value="cooldown">
 				<attribute key="value" value="300000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="slot" value="ammo"/>
-			<attribute key="vocation" value="Paladin;true, Royal Paladin"/>
+			<attribute key="slot" value="ammo" />
+			<attribute key="vocation" value="Paladin;true, Royal Paladin" />
 		</attribute>
 	</item>
 	<item id="51272" name="ink claw">
-		<attribute key="primarytype" value="decoration"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentenergy" value="2"/>
-		<attribute key="weight" value="310"/>
+		<attribute key="primarytype" value="decoration" />
+		<attribute key="showAttributes" value="1" />
+		<attribute key="absorbpercentenergy" value="2" />
+		<attribute key="weight" value="310" />
 		<attribute key="augments" value="1">
 			<attribute key="sorcerer familiar" value="cooldown">
 				<attribute key="value" value="300000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="slot" value="ammo"/>
-			<attribute key="vocation" value="Sorcerer;true, Master Sorcerer"/>
+			<attribute key="slot" value="ammo" />
+			<attribute key="vocation" value="Sorcerer;true, Master Sorcerer" />
 		</attribute>
 	</item>
 	<item id="51273" name="ink vine">
-		<attribute key="primarytype" value="decoration"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentenergy" value="2"/>
-		<attribute key="weight" value="230"/>
+		<attribute key="primarytype" value="decoration" />
+		<attribute key="showAttributes" value="1" />
+		<attribute key="absorbpercentenergy" value="2" />
+		<attribute key="weight" value="230" />
 		<attribute key="augments" value="1">
 			<attribute key="druid familiar" value="cooldown">
 				<attribute key="value" value="300000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="slot" value="ammo"/>
-			<attribute key="vocation" value="Druid;true, Elder Druid"/>
+			<attribute key="slot" value="ammo" />
+			<attribute key="vocation" value="Druid;true, Elder Druid" />
 		</attribute>
 	</item>
 	<item id="51274" name="ink brush">
-		<attribute key="primarytype" value="decoration"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentenergy" value="2"/>
-		<attribute key="weight" value="230"/>
+		<attribute key="primarytype" value="decoration" />
+		<attribute key="showAttributes" value="1" />
+		<attribute key="absorbpercentenergy" value="2" />
+		<attribute key="weight" value="230" />
 		<attribute key="augments" value="1">
 			<attribute key="monk familiar" value="cooldown">
 				<attribute key="value" value="300000" />
 			</attribute>
 		</attribute>
 		<attribute key="script" value="moveevent">
-			<attribute key="slot" value="ammo"/>
-			<attribute key="vocation" value="Monk;true, Exalted Monk"/>
+			<attribute key="slot" value="ammo" />
+			<attribute key="vocation" value="Monk;true, Exalted Monk" />
 		</attribute>
 	</item>
 	<item id="51275" article="a" name="greater garlic necklace">
-		<attribute key="primarytype" value="amulets and necklaces"/>
-		<attribute key="showCharges" value="1"/>
-		<attribute key="showAttributes" value="1"/>
-		<attribute key="absorbpercentlifedrain" value="50"/>
-		<attribute key="charges" value="500"/>
-		<attribute key="weight" value="630"/>
+		<attribute key="primarytype" value="amulets and necklaces" />
+		<attribute key="showCharges" value="1" />
+		<attribute key="showAttributes" value="1" />
+		<attribute key="absorbpercentlifedrain" value="50" />
+		<attribute key="charges" value="500" />
+		<attribute key="weight" value="630" />
 		<attribute key="script" value="moveevent">
-			<attribute key="slot" value="necklace"/>
+			<attribute key="slot" value="necklace" />
 		</attribute>
 	</item>
 	<item id="51294" name="spirit bind">
@@ -85147,135 +85147,135 @@ Granted by TibiaGoals.com" />
 		</attribute>
 	</item>
 	<item id="51419" article="a" name="paper plane">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="50"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="50" />
 	</item>
 	<item id="51420" article="a" name="paper boat">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="50"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="50" />
 	</item>
 	<item id="51422" article="a" name="star ink">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="60"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="60" />
 	</item>
 	<item id="51423" article="a" name="book with a dragon">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="800"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="800" />
 	</item>
 	<item id="51425" article="a" name="book with an hourglass">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="800"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="800" />
 	</item>
 	<item id="51426" article="a" name="sealing wax">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="100"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="100" />
 	</item>
 	<item id="51427" article="a" name="torn page">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51442" article="a" name="blank imbuement scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51443" name="etcher">
-		<attribute key="weight" value="150"/>
+		<attribute key="weight" value="150" />
 	</item>
 	<item id="51444" article="a" name="powerful bash scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51445" article="a" name="powerful blockade scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51446" article="a" name="powerful chop scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51447" article="a" name="powerful cloud fabric scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51448" article="a" name="powerful demon presence scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51449" article="a" name="powerful dragon hide scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51450" article="a" name="powerful electrify scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51451" article="a" name="powerful epiphany scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51452" article="a" name="powerful featherweight scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51453" article="a" name="powerful frost scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51454" article="a" name="powerful lich shroud scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51455" article="a" name="powerful precision scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51456" article="a" name="powerful punch scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51457" article="a" name="powerful quara scale scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51458" article="a" name="powerful reap scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51459" article="a" name="powerful scorch scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51460" article="a" name="powerful slash scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51461" article="a" name="powerful snake skin scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51462" article="a" name="powerful strike scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51463" article="a" name="powerful swiftness scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51464" article="a" name="powerful vampirism scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51465" article="a" name="powerful venom scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51466" article="a" name="powerful vibrancy scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51467" article="a" name="powerful void scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51468" name="dread doll">
 		<attribute key="description" value="Souvenir from Thais Museum" />
@@ -85285,145 +85285,145 @@ Granted by TibiaGoals.com" />
 		<attribute key="weight" value="630" />
 	</item>
 	<item id="51471" article="a" name="tiny bat coffin">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="630"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="630" />
 	</item>
 	<item id="51472" article="a" name="chain leash">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51473" article="a" name="blood amulet">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51474" article="a" name="piece of frozen night">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51475" article="a" name="ritual bone knife">
-		<attribute key="primarytype" value="sword weapons"/>
-		<attribute key="weaponType" value="sword"/>
-		<attribute key="attack" value="5"/>
-		<attribute key="defense" value="1"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="sword weapons" />
+		<attribute key="weaponType" value="sword" />
+		<attribute key="attack" value="5" />
+		<attribute key="defense" value="1" />
+		<attribute key="weight" value="20" />
 		<attribute key="script" value="moveevent;weapon">
-			<attribute key="weaponType" value="sword"/>
-			<attribute key="slot" value="hand"/>
+			<attribute key="weaponType" value="sword" />
+			<attribute key="slot" value="hand" />
 		</attribute>
 	</item>
 	<item id="51476" article="a" name="pot of orcish warpaint">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51477" article="a" name="orcish toothbrush">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51478" article="a" name="bone rattle">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51479" name="spiked bracers">
 		<attribute key="weight" value="20" />
 	</item>
 	<item id="51480" article="a" name="blood hood">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51481" name="blood sceptre">
 		<attribute key="weight" value="20" />
 	</item>
 	<item id="51482" article="a" name="bloodshot giant eye">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51483" name="blood crown">
 		<attribute key="weight" value="20" />
 	</item>
 	<item id="51484" article="a" name="heart amphora">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51485" article="a" name="bone fibula">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51421" article="a" name="colourful quill">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="60"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="60" />
 	</item>
 	<item id="51486" name="spiked gorget">
 		<attribute key="weight" value="20" />
 	</item>
 	<item id="51487" article="a" name="norcferatu talisman">
-		<attribute key="primarytype" value="creature products"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="primarytype" value="creature products" />
+		<attribute key="weight" value="20" />
 	</item>
 	<item id="51494" article="a" name="slain crusader">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51495" article="a" name="slain crusader">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51494"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51494" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51496" article="a" name="slain crusader">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51495"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51495" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51497" article="a" name="slain crusader">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51496"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51496" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51498" article="a" name="slain bramble wyrmling">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51499" article="a" name="slain bramble wyrmling">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51498"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51498" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51500" article="a" name="slain bramble wyrmling">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51499"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51499" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51501" article="a" name="slain bramble wyrmling">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51500"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51500" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51504" article="a" name="slain bluebeak">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51505" article="a" name="slain bluebeak">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51504"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51504" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51506" article="a" name="slain cinder wyrmling">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51507" article="a" name="slain cinder wyrmling">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51506"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51506" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51508" article="a" name="slain cinder wyrmling">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51507"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51507" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51509" article="a" name="slain cinder wyrmling">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51508"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51508" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51510" name="painted healing herbs">
 		<attribute key="weight" value="100" />
@@ -85441,219 +85441,219 @@ Granted by TibiaGoals.com" />
 		<attribute key="weight" value="630" />
 	</item>
 	<item id="51529" article="a" name="slain norcferatu nightweaver">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51530"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51530" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51530" article="a" name="slain norcferatu nightweaver">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51531"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51531" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51531" article="a" name="slain norcferatu nightweaver">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51532"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51532" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51532" article="a" name="slain norcferatu nightweaver">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51533" article="a" name="slain norcferatu heartless">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51534"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51534" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51534" article="a" name="slain norcferatu heartless">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51535"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51535" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51535" article="a" name="slain norcferatu heartless">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51536"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51536" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51536" article="a" name="slain norcferatu heartless">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51537" article="a" name="slain dworc shadowstalker">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51540"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51540" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51538" article="a" name="slain orclops bloodbreaker">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51543"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51543" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51540" article="a" name="slain dworc shadowstalker">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51541"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51541" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51541" article="a" name="slain dworc shadowstalker">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51542"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51542" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51542" article="a" name="slain dworc shadowstalker">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51543" article="a" name="slain orclops bloodbreaker">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51544"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51544" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51544" article="a" name="slain orclops bloodbreaker">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51545"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51545" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51545" article="a" name="slain orclops bloodbreaker">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51546" article="a" name="slain varg">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51547"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51547" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51547" article="a" name="slain varg">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51548"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51548" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51548" article="a" name="slain varg">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51549" article="a" name="slain headwalker">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51550" article="a" name="slain headwalker">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51549"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51549" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51551" article="a" name="slain headwalker">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51550"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51550" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51552" article="a" name="slain headwalker">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51551"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51551" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51553" article="a" name="slain shell drake">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51554" article="a" name="slain shell drake">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51553"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51553" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51555" article="a" name="slain shell drake">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51554"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51554" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51556" article="a" name="slain shell drake">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51555"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51555" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51561" article="a" name="slain lion hydra">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51562" article="a" name="slain lion hydra">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51561"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51561" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51563" article="a" name="slain lion hydra">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51562"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51562" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51564" article="a" name="slain lion hydra">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51563"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51563" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51568" name="boat ticket">
 		<attribute key="weight" value="50" />
 	</item>
 	<item id="51584" article="a" name="slain gloom maw">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51585"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51585" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51585" article="a" name="slain gloom maw">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51586"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51586" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51586" article="a" name="slain gloom maw">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51587"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51587" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51587" article="a" name="slain gloom maw">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51595" article="a" name="slain vampiric essence">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51594"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51594" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51594" article="a" name="slain vampiric essence">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51593"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51593" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51593" article="a" name="slain vampiric essence">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51592"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51592" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51592" article="a" name="slain vampiric maessencew">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51572" article="a" name="slain vladrukh">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51571"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51571" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51571" article="a" name="slain vladrukh">
-		<attribute key="duration" value="300"/>
-		<attribute key="decayTo" value="51570"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="300" />
+		<attribute key="decayTo" value="51570" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51570" article="a" name="slain vladrukh">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="51569"/>
-		<attribute key="containersize" value="24"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="51569" />
+		<attribute key="containersize" value="24" />
 	</item>
 	<item id="51569" article="a" name="slain vladrukh">
-		<attribute key="duration" value="60"/>
-		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60" />
+		<attribute key="decayTo" value="0" />
 	</item>
 	<item id="51588" article="a" name="proficiency catalyst">
-		<attribute key="primarytype" value="valuables"/>
-		<attribute key="weight" value="500"/>
+		<attribute key="primarytype" value="valuables" />
+		<attribute key="weight" value="500" />
 	</item>
 	<item id="51589" article="a" name="greater proficiency catalyst">
-		<attribute key="primarytype" value="valuables"/>
-		<attribute key="weight" value="750"/>
+		<attribute key="primarytype" value="valuables" />
+		<attribute key="weight" value="750" />
 	</item>
 	<item id="51623" name="deer fur brush">
 		<attribute key="weight" value="100" />
@@ -85762,111 +85762,111 @@ Granted by TibiaGoals.com" />
 		<attribute key="weight" value="1000" />
 	</item>
 	<item id="51724" article="a" name="intricate bash scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51725" article="a" name="intricate blockade scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51726" article="a" name="intricate chop scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51727" article="a" name="intricate cloud fabric scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51728" article="a" name="intricate demon presence scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51729" article="a" name="intricate dragon hide scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51730" article="a" name="intricate electrify scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51731" article="a" name="intricate epiphany scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51732" article="a" name="intricate featherweight scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51733" article="a" name="intricate frost scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51734" article="a" name="intricate lich shroud scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51735" article="a" name="intricate precision scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51736" article="a" name="intricate punch scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51737" article="a" name="intricate quara scale scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51738" article="a" name="intricate reap scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51739" article="a" name="intricate scorch scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51740" article="a" name="intricate slash scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51741" article="a" name="intricate snake skin scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51742" article="a" name="intricate strike scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51743" article="a" name="intricate swiftness scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51744" article="a" name="intricate vampirism scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51745" article="a" name="intricate venom scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51746" article="a" name="intricate vibrancy scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="51747" article="a" name="intricate void scroll">
-		<attribute key="primarytype" value="documents and papers"/>
-		<attribute key="weight" value="250"/>
+		<attribute key="primarytype" value="documents and papers" />
+		<attribute key="weight" value="250" />
 	</item>
 	<item id="50547" name="stairs">
-		<attribute key="floorchange" value="north"/>
+		<attribute key="floorchange" value="north" />
 	</item>
 	<item id="50551" name="stairs">
-		<attribute key="floorchange" value="west"/>
+		<attribute key="floorchange" value="west" />
 	</item>
 	<item id="50553" name="stairs">
-		<attribute key="floorchange" value="east"/>
+		<attribute key="floorchange" value="east" />
 	</item>
 	<item id="50555" name="stairs">
-		<attribute key="floorchange" value="south"/>
+		<attribute key="floorchange" value="south" />
 	</item>
 </items>


### PR DESCRIPTION
Cleaned up augment attributes across all norcferatu items with proper XML spacing and corrected percentages. Normalized Greater Tiger Clash, Ethereal Spear and other augments formatting.
