### PR TITLE
fix: Outfitts and Mounts memory leaks

### DIFF
--- a/src/creatures/appearance/mounts/mounts.cpp
+++ b/src/creatures/appearance/mounts/mounts.cpp
@@ -193,17 +193,17 @@ bool Mounts::addAttributes(uint32_t playerId, uint8_t mountId) {
 
 	// Apply Conditions
 	if (mount->manaShield) {
-		const auto &condition = Condition::createCondition(CONDITIONID_MOUNT, CONDITION_MANASHIELD, -1, 0);
+		auto condition = Condition::createCondition(CONDITIONID_MOUNT, CONDITION_MANASHIELD, -1, 0);
 		player->addCondition(condition);
 	}
 
 	if (mount->invisible) {
-		const auto &condition = Condition::createCondition(CONDITIONID_MOUNT, CONDITION_INVISIBLE, -1, 0);
+		auto condition = Condition::createCondition(CONDITIONID_MOUNT, CONDITION_INVISIBLE, -1, 0);
 		player->addCondition(condition);
 	}
 
 	if (mount->regeneration) {
-		const auto &condition = Condition::createCondition(CONDITIONID_MOUNT, CONDITION_REGENERATION, -1, 0);
+		auto condition = Condition::createCondition(CONDITIONID_MOUNT, CONDITION_REGENERATION, -1, 0);
 		if (mount->healthGain) {
 			condition->setParam(CONDITION_PARAM_HEALTHGAIN, mount->healthGain);
 		}
@@ -279,12 +279,12 @@ bool Mounts::removeAttributes(uint32_t playerId, uint8_t mountId) {
 		return mount->id == mountId;
 	});
 
-	auto mount = *it;
-
-	if (!mount) {
+	if (it == mounts.end()) {
 		g_logger().warn("[Mounts::removeAttributes] Mount with ID {} not found.", mountId);
 		return false;
 	}
+
+	auto mount = *it;
 
 	// Remove conditions
 	if (mount->manaShield) {

--- a/src/creatures/appearance/outfit/outfit.cpp
+++ b/src/creatures/appearance/outfit/outfit.cpp
@@ -260,12 +260,12 @@ bool Outfits::addAttributes(uint32_t playerId, uint32_t outfitId, uint16_t sex, 
 
 	// Apply Conditions
 	if (outfit->manaShield) {
-		const auto &condition = Condition::createCondition(CONDITIONID_OUTFIT, CONDITION_MANASHIELD, -1, 0);
+		auto condition = Condition::createCondition(CONDITIONID_OUTFIT, CONDITION_MANASHIELD, -1, 0);
 		player->addCondition(condition);
 	}
 
 	if (outfit->invisible) {
-		const auto &condition = Condition::createCondition(CONDITIONID_OUTFIT, CONDITION_INVISIBLE, -1, 0);
+		auto condition = Condition::createCondition(CONDITIONID_OUTFIT, CONDITION_INVISIBLE, -1, 0);
 		player->addCondition(condition);
 	}
 
@@ -274,7 +274,7 @@ bool Outfits::addAttributes(uint32_t playerId, uint32_t outfitId, uint16_t sex, 
 	}
 
 	if (outfit->regeneration) {
-		const auto &condition = Condition::createCondition(CONDITIONID_OUTFIT, CONDITION_REGENERATION, -1, 0);
+		auto condition = Condition::createCondition(CONDITIONID_OUTFIT, CONDITION_REGENERATION, -1, 0);
 		if (outfit->healthGain) {
 			condition->setParam(CONDITION_PARAM_HEALTHGAIN, outfit->healthGain);
 		}


### PR DESCRIPTION
### Outfits

- Potential weakness: creating conditions via Condition::createCondition(...) was stored in const auto& (referring to temporary), which depends on extending the lifetime of the temporary. Although the lifetime is extended in scope, it is safer to keep it as a local value.

### Mounts
- Subtle risk: linking temporary objects to `const auto&` can confuse object lifetime management. Although lifetime is extended to the local scope, it is more robust to maintain it by value.
- Additional bug identified in `removeAttributes`: dereferencing an iterator without checking `end()`, which can cause a crash.