### PR TITLE
fix: item attribute

### DIFF
--- a/src/items/functions/item/attribute.cpp
+++ b/src/items/functions/item/attribute.cpp
@@ -35,7 +35,7 @@ const std::string &ItemAttribute::getAttributeString(ItemAttribute_t type) const
 		return emptyString;
 	}
 
-	return *attribute->getString();
+	return attribute->getString();
 }
 
 const int64_t &ItemAttribute::getAttributeValue(ItemAttribute_t type) const {

--- a/src/items/functions/item/attribute.hpp
+++ b/src/items/functions/item/attribute.hpp
@@ -94,11 +94,11 @@ public:
 		return type;
 	}
 
-	std::variant<int64_t, std::shared_ptr<std::string>> getDefaultValueForType(ItemAttribute_t attributeType) const {
+	std::variant<int64_t, std::string> getDefaultValueForType(ItemAttribute_t attributeType) const {
 		if (ItemAttributeHelper::isAttributeInteger(attributeType)) {
 			return 0;
 		} else if (ItemAttributeHelper::isAttributeString(attributeType)) {
-			return std::make_shared<std::string>();
+			return std::string();
 		} else {
 			return {};
 		}
@@ -110,8 +110,8 @@ public:
 		}
 	}
 	void setValue(const std::string &newValue) {
-		if (std::holds_alternative<std::shared_ptr<std::string>>(value)) {
-			value = std::make_shared<std::string>(newValue);
+		if (std::holds_alternative<std::string>(value)) {
+			value = newValue;
 		}
 	}
 	const int64_t &getInteger() const {
@@ -122,17 +122,17 @@ public:
 		return emptyValue;
 	}
 
-	std::shared_ptr<std::string> getString() const {
-		if (std::holds_alternative<std::shared_ptr<std::string>>(value)) {
-			return std::get<std::shared_ptr<std::string>>(value);
+	const std::string &getString() const {
+		if (std::holds_alternative<std::string>(value)) {
+			return std::get<std::string>(value);
 		}
-		static std::shared_ptr<std::string> emptyPtr;
-		return emptyPtr;
+		static std::string emptyValue;
+		return emptyValue;
 	}
 
 private:
 	ItemAttribute_t type;
-	std::variant<int64_t, std::shared_ptr<std::string>> value;
+	std::variant<int64_t, std::string> value;
 };
 
 class ItemAttribute : public ItemAttributeHelper {


### PR DESCRIPTION
### Summary

- Replaced attribute string storage from `std::shared_ptr<std::string>` to direct `std::string` usage to avoid unnecessary allocations and lifetime-related risks.
- Updated string access points to return `const std::string&`, eliminating the need to dereference pointers and reducing the risk of dangling references.

### Why This Helps Prevent Leaks?

- Removing `std::shared_ptr<std::string>` avoids repeated allocations and the risk of keeping shared references alive longer than necessary.
- Returning references to `std::string` objects within `Attributes` ensures their lifetimes are strictly controlled by the containing `std::vector<Attributes>`; when an attribute is removed, no external dangling pointers remain.
- `std::variant` handles memory automatically, without requiring manual deallocation.
