### PR TITLE
fix: Avoid possible crashes with  getCorpseFromItem and playerRewardChestCollect

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5741,7 +5741,10 @@ std::shared_ptr<Item> Game::getItemToLoot(const std::shared_ptr<Player> &player,
 std::shared_ptr<Container> Game::getCorpseFromItem(const std::shared_ptr<Item> &item, const Position &pos) {
 	std::shared_ptr<Container> corpse;
 	if (pos.x == 0xFFFF) {
-		corpse = item->getParent()->getContainer();
+		const auto &parent = item->getParent();
+		if (parent) {
+			corpse = parent->getContainer();
+		}
 		if (corpse && corpse->getID() == ITEM_BROWSEFIELD) {
 			corpse = item->getContainer();
 			browseField = true;
@@ -11125,7 +11128,15 @@ void Game::playerRewardChestCollect(uint32_t playerId, const Position &pos, uint
 		return;
 	}
 
-	playerRewardChest->setParent(item->getContainer()->getParent()->getTile());
+	const auto &container = item->getContainer();
+	if (container) {
+		const auto &parent = container->getParent();
+		const auto &tile = parent ? parent->getTile() : nullptr;
+		if (tile) {
+			playerRewardChest->setParent(tile);
+		}
+	}
+
 	for (const auto &[mapRewardId, reward] : player->rewardMap) {
 		reward->setParent(playerRewardChest);
 	}


### PR DESCRIPTION
### getCorpseFromItem  
- Protected the `item->getParent()->getContainer()` chain by checking `parent` before dereferencing, preserving special handling for `ITEM_BROWSEFIELD` without risking a `nullptr` dereference.

### playerRewardChestCollect  
- Safeguarded the `item->getContainer()->getParent()->getTile()` access chain by validating `container`, `parent`, and `tile` before use. If any component is null, the code avoids a crash and proceeds by directing rewards to `playerRewardChest`.