### PR TITLE
fix: ignore removed creatures or creatures with no HP when assembling tile descriptions

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1588,6 +1588,10 @@ void ProtocolGame::GetTileDescription(const std::shared_ptr<Tile> &tile, Network
 	if (creatures) {
 		bool playerAdded = false;
 		for (auto creature : std::ranges::reverse_view(*creatures)) {
+			if (!creature || creature->isRemoved() || !creature->isAlive()) {
+				continue;
+			}
+
 			if (!player->canSeeCreature(creature)) {
 				continue;
 			}


### PR DESCRIPTION
PR from https://github.com/opentibiabr/canary/pull/3765