### PR TITLE
fix: foreign key constraint "account_vipgroups" and "player_charms"

### DIFF
--- a/data/migrations/8.lua
+++ b/data/migrations/8.lua
@@ -25,6 +25,6 @@ function onUpdateDatabase()
 		`rune_void` INT(250) NULL ,
 		`UsedRunesBit` VARCHAR(250) NULL ,
 		`UnlockedRunesBit` VARCHAR(250) NULL,
-		`tracker list` BLOB NULL ) ENGINE = InnoDB DEFAULT CHARSET=utf8;
+		`tracker_list` BLOB NULL ) ENGINE = InnoDB DEFAULT CHARSET=utf8;
 	]])
 end

--- a/schema.sql
+++ b/schema.sql
@@ -226,7 +226,7 @@ CREATE TABLE IF NOT EXISTS `account_vipgroups` (
     `account_id` int(11) UNSIGNED NOT NULL COMMENT 'id of account whose vip group entry it is',
     `name` varchar(128) NOT NULL,
     `customizable` BOOLEAN NOT NULL DEFAULT '1',
-    CONSTRAINT `account_vipgroups_pk` PRIMARY KEY (`id`, `account_id`),
+    CONSTRAINT `account_vipgroups_pk` PRIMARY KEY (`id`),
     CONSTRAINT `account_vipgroups_accounts_fk`
         FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`)
         ON DELETE CASCADE
@@ -582,7 +582,7 @@ CREATE TABLE IF NOT EXISTS `player_charms` (
     `UsedRunesBit` INT NOT NULL DEFAULT '0',
     `UnlockedRunesBit` INT NOT NULL DEFAULT '0',
     `charms` BLOB NULL,
-    `tracker list` BLOB NULL,
+    `tracker_list` BLOB NULL,
     CONSTRAINT `player_charms_players_fk`
         FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
 ) ENGINE = InnoDB DEFAULT CHARSET=utf8;

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -528,7 +528,7 @@ void IOLoginDataLoad::loadPlayerBestiaryCharms(const std::shared_ptr<Player> &pl
 		}
 
 		unsigned long attrBestSize;
-		const char* Bestattr = result->getStream("tracker list", attrBestSize);
+		const char* Bestattr = result->getStream("tracker_list", attrBestSize);
 		PropStream propBestStream;
 		propBestStream.init(Bestattr, attrBestSize);
 

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -483,7 +483,7 @@ bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &pl
 	}
 	size_t trackerSize;
 	const char* trackerList = propBestiaryStream.getStream(trackerSize);
-	query << " `tracker list` = " << db.escapeBlob(trackerList, static_cast<uint32_t>(trackerSize));
+	query << " `tracker_list` = " << db.escapeBlob(trackerList, static_cast<uint32_t>(trackerSize));
 	query << " WHERE `player_id` = " << player->getGUID();
 
 	if (!db.executeQuery(query.str())) {


### PR DESCRIPTION
Fixes two issues preventing the **schema.sql** file from importing correctly into MySQL.

1. Fix Foreign Key Constraint Error (Error Code: 6125):
The table **`account_vipgrouplist`** attempts to create a Foreign Key referencing the id column of **`account_vipgroups`**. However, the **`account_vipgroups`** table was originally defined with a composite Primary Key (id, account_id). MySQL requires the referenced column in a foreign key constraint to be a unique key or the sole primary key. This caused the import to fail with **Error 6125: Failed to add the foreign key constraint.**
Updated the `account_vipgroups` table definition to set the Primary Key strictly on the id column.

2. Fix Syntax Error in player_charms:
Renamed the column to **`tracker_list`** (standard snake_case) to resolve the syntax error and maintain naming consistency.

```sql
-- account_vipgroups (Before)
PRIMARY KEY (`id`, `account_id`)

-- account_vipgroups (After)
PRIMARY KEY (`id`)

-- player_charms (Before)
`tracker list` BLOB NULL

-- player_charms (After)
`tracker_list` BLOB NULL