### PR TITLE
fix: Divine Grenade cooldown

### DIFF
--- a/data/scripts/spells/attack/divine_grenade.lua
+++ b/data/scripts/spells/attack/divine_grenade.lua
@@ -75,17 +75,11 @@ function spell.onCastSpell(creature, var)
 		return false
 	end
 
-	local cooldownByGrade = { 26, 20, 14 }
-	local cooldown = cooldownByGrade[grade]
-
 	var.instantName = "Divine Grenade Cast"
 	if combatCast:execute(creature, var) then
 		local target = Creature(var:getNumber())
 		local position = creature:getPosition():getWithinRange(target:getPosition(), 4)
 		position:sendMagicEffect(CONST_ME_DIVINE_GRENADE)
-		local condition = Condition(CONDITION_SPELLCOOLDOWN, CONDITIONID_DEFAULT, 258)
-		condition:setTicks((cooldown * 1000) / configManager.getFloat(configKeys.RATE_SPELL_COOLDOWN))
-		creature:addCondition(condition)
 		return true
 	end
 	return false
@@ -101,7 +95,7 @@ spell:isPremium(true)
 spell:range(7)
 spell:needTarget(true)
 spell:blockWalls(true)
-spell:cooldown(1000) -- Cooldown is calculated on the casting
+spell:cooldown(26 * 1000)
 spell:groupCooldown(2 * 1000)
 spell:needLearn(true)
 spell:vocation("paladin;true", "royal paladin;true")

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -2155,12 +2155,12 @@ void PlayerWheel::registerPlayerBonusData() {
 		}
 		if (m_playerBonusData.stages.divineGrenade >= 2) {
 			WheelSpells::Bonus bonus;
-			bonus.decrease.cooldown = 4 * 1000;
+			bonus.decrease.cooldown = 6 * 1000;
 			addSpellBonus("Divine Grenade", bonus);
 		}
 		if (m_playerBonusData.stages.divineGrenade >= 3) {
 			WheelSpells::Bonus bonus;
-			bonus.decrease.cooldown = 6 * 1000;
+			bonus.decrease.cooldown = 4 * 1000;
 			addSpellBonus("Divine Grenade", bonus);
 		}
 	} else {


### PR DESCRIPTION
This PR adjusts the cooldown of the Divine Grenade spell and allows for true scaling of its cooldown according to the spell level unlocked in the wheel of destiny. It also works perfectly with cooldown reduction gems.

Note: It's always important to remember that in Tibia, no cooldown time can be reduced to less than 50% of its original time.

Fix #530.