### PR TITLE
improve: ItemAttribute Safety Improvements

### DIFF
--- a/src/items/functions/item/attribute.cpp
+++ b/src/items/functions/item/attribute.cpp
@@ -53,11 +53,9 @@ const int64_t &ItemAttribute::getAttributeValue(ItemAttribute_t type) const {
 }
 
 const Attributes* ItemAttribute::getAttribute(ItemAttribute_t type) const {
-	if (hasAttribute(type)) {
-		for (const Attributes &attribute : attributeVector) {
-			if (attribute.getAttributeType() == type) {
-				return &attribute;
-			}
+	for (auto it = attributeVector.cbegin(); it != attributeVector.cend(); ++it) {
+		if (it->getAttributeType() == type) {
+			return &*it;
 		}
 	}
 	return nullptr;
@@ -120,10 +118,12 @@ const std::map<std::string, CustomAttribute, std::less<>> &ItemAttribute::getCus
 =============================
 */
 const CustomAttribute* ItemAttribute::getCustomAttribute(const std::string &attributeName) const {
-	if (customAttributeMap.contains(asLowerCaseString(attributeName))) {
-		return &customAttributeMap.at(asLowerCaseString(attributeName));
+	const auto key = asLowerCaseString(attributeName);
+	const auto it = customAttributeMap.find(key);
+	if (it == customAttributeMap.end()) {
+		return nullptr;
 	}
-	return nullptr;
+	return &it->second;
 }
 
 void ItemAttribute::setCustomAttribute(const std::string &key, const int64_t value) {


### PR DESCRIPTION
## Changes
- `getAttribute` now performs a single pass over `attributeVector` using iterators and returns a stable pointer.
- `getCustomAttribute` now uses `find` with a precomputed lowercase key and returns `&it->second`, avoiding double lookup and exception risk.

## Rationale
- Avoids two-pass scans (`hasAttribute` then scan), which could become inconsistent if the vector changes between passes.
- Prevents a potential race window using `contains(...)` followed by `at(...)` on the map; `find` is single-pass and non-throwing when absent.
- Maintains returning `nullptr` when an attribute or custom attribute is not present, keeping existing semantic contracts.
