### PR TITLE
fix: Adjust monk attack harmony bonus calculation

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -78,10 +78,10 @@ static void applyImproveMonkAttackSpender(const std::shared_ptr<Player> &player,
 		return;
 	}
 
-	uint8_t baseHarmonyBonusPercent = 8; // 8, 16, 32, 64, 128
+	uint8_t baseHarmonyBonusPercent = 7; // 7, 14, 28, 56, 112
 
 	if (player->getVirtue() == VIRTUE_HARMONY) {
-		baseHarmonyBonusPercent += (player->isSerene() ? 8 : 4);
+		baseHarmonyBonusPercent += (player->isSerene() ? 6 : 3);
 	}
 
 	const uint8_t stage = player->wheel()->getStage(WheelStage_t::ASCETIC);


### PR DESCRIPTION
Reduced the base harmony bonus percent from 8 to 7 and adjusted the bonus increment for serene and non-serene players. This change fine-tunes the monk attack spender's harmony bonus scaling.

Based on https://tibia.fandom.com/wiki/Harmony