### PR TITLE
fix: raid execution and repetition logic

### DIFF
--- a/src/lua/creature/raids.hpp
+++ b/src/lua/creature/raids.hpp
@@ -113,9 +113,10 @@ public:
 	void resetRaid();
 
 	std::shared_ptr<RaidEvent> getNextRaidEvent();
-	void setState(RaidState_t newState) {
-		state = newState;
+	RaidState_t getState() const {
+		return state;
 	}
+
 	const std::string &getName() const {
 		return name;
 	}
@@ -133,6 +134,13 @@ public:
 		return repeat;
 	}
 
+	bool isExecuted() const {
+		return executed;
+	}
+	void setExecuted(bool v) {
+		executed = v;
+	}
+
 	void stopEvents();
 
 private:
@@ -145,6 +153,7 @@ private:
 	uint32_t nextEventEvent = 0;
 	bool loaded = false;
 	bool repeat;
+	bool executed = false;
 };
 
 class RaidEvent {

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -774,7 +774,7 @@ int GameFunctions::luaGameStartRaid(lua_State* L) {
 		return 1;
 	}
 
-	if (g_game().raids.getRunning()) {
+	if (g_game().raids.getRunning() || raid->getState() == RAIDSTATE_EXECUTING) {
 		lua_pushnumber(L, RETURNVALUE_ANOTHERRAIDISALREADYEXECUTING);
 		return 1;
 	}


### PR DESCRIPTION
Added checks to prevent non-repeatable raids from executing multiple times and track execution state.
Refactored raid state management, introduced executed flag, and updated related functions to ensure correct raid lifecycle handling.
Also improved monster spawn event to trigger onSpawn.

Fixes: https://github.com/zimbadev/crystalserver/issues/568