### PR TITLE
fix: getSpectators and thread pool

### DIFF
--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -19,6 +19,9 @@
 
 #include "game/game.hpp"
 #include "utils/tools.hpp"
+#include "lib/di/container.hpp"
+
+#include <csignal>
 
 /**
  * Regardless of how many cores your computer have, we want at least
@@ -31,8 +34,15 @@
 	#define DEFAULT_NUMBER_OF_THREADS 4
 #endif
 
+ThreadPool &ThreadPool::getInstance() {
+	return inject<ThreadPool>();
+}
+
 ThreadPool::ThreadPool(Logger &logger, const uint32_t threadCount /*= std::thread::hardware_concurrency()*/) :
-	BS::thread_pool<BS::tp::none>(threadCount > 0 ? threadCount : std::max<int>(getNumberOfCores(), DEFAULT_NUMBER_OF_THREADS)), logger(logger) {
+	logger(logger),
+	pool { std::make_unique<BS::thread_pool<BS::tp::none>>(
+		threadCount > 0 ? threadCount : std::max<int>(getNumberOfCores(), DEFAULT_NUMBER_OF_THREADS)
+	) } {
 	start();
 }
 
@@ -45,13 +55,13 @@ void ThreadPool::shutdown() {
 		return;
 	}
 
-	logger.info("Shutting down thread pool...");
-	{
-		std::unique_lock<std::mutex> lock(mutex);
-		stopped = true;
-		condition.notify_all();
-	}
+	stopped = true;
 
-	wait();
+	logger.info("Shutting down thread pool...");
+	pool.reset();
+
+	std::signal(SIGINT, SIG_DFL);
+	std::signal(SIGTERM, SIG_DFL);
+
 	logger.info("Thread pool shutdown complete.");
 }

--- a/src/lib/thread/thread_pool.hpp
+++ b/src/lib/thread/thread_pool.hpp
@@ -19,13 +19,38 @@
 
 #include "BS_thread_pool.hpp"
 
-class ThreadPool : public BS::thread_pool<BS::tp::none> {
+class ThreadPool {
 public:
 	explicit ThreadPool(Logger &logger, const uint32_t threadCount = std::thread::hardware_concurrency());
 
 	// Ensures that we don't accidentally copy it
 	ThreadPool(const ThreadPool &) = delete;
 	ThreadPool &operator=(const ThreadPool &) = delete;
+
+	static ThreadPool &getInstance();
+
+	template <typename F>
+	void detach_task(F &&f) {
+		pool->detach_task(std::forward<F>(f));
+	}
+
+	template <typename F>
+	auto submit_loop(std::size_t first, std::size_t last, F &&f) {
+		return pool->submit_loop(first, last, std::forward<F>(f));
+	}
+
+	template <typename F, typename... Args>
+	auto submit_task(F &&f, Args &&... args) {
+		return pool->submit_task(std::forward<F>(f), std::forward<Args>(args)...);
+	}
+
+	void wait_for_tasks() {
+		pool->wait();
+	}
+
+	auto get_thread_count() const noexcept {
+		return pool->get_thread_count();
+	}
 
 	void start() const;
 	void shutdown();
@@ -51,5 +76,9 @@ private:
 	std::condition_variable condition;
 
 	Logger &logger;
-	bool stopped = false;
+	std::atomic<bool> stopped { false };
+
+	std::unique_ptr<BS::thread_pool<BS::tp::none>> pool;
 };
+
+constexpr auto g_threadPool = ThreadPool::getInstance;

--- a/src/map/spectators.cpp
+++ b/src/map/spectators.cpp
@@ -139,16 +139,10 @@ CreatureVector Spectators::getSpectators(const Position &centerPos, bool multifl
 	const int32_t endy2 = y2 - (y2 & SECTOR_MASK);
 
 	CreatureVector spectators;
-	// More accurate reserve based on sector count and typical creature density
-	const uint32_t sectorCount = ((endx2 - startx1) / SECTOR_SIZE + 1) * ((endy2 - starty1) / SECTOR_SIZE + 1);
-	spectators.reserve(sectorCount * 8); // Estimate 8 creatures per sector
+	spectators.reserve(std::max<uint8_t>(MAP_MAX_VIEW_PORT_X, MAP_MAX_VIEW_PORT_Y) * 2);
 
 	const MapSector* startSector = g_game().map.getMapSector(startx1, starty1);
 	const MapSector* sectorS = startSector;
-
-	// Pre-calculate type checks
-	const bool needsTypeCheck = onlyPlayers || onlyMonsters || onlyNpcs;
-
 	for (int32_t ny = starty1; ny <= endy2; ny += SECTOR_SIZE) {
 		const MapSector* sectorE = sectorS;
 		for (int32_t nx = startx1; nx <= endx2; nx += SECTOR_SIZE) {
@@ -160,19 +154,11 @@ CreatureVector Spectators::getSpectators(const Position &centerPos, bool multifl
 
 				for (const auto &creature : nodeList) {
 					const auto &cpos = creature->getPosition();
-
-					// Check Z range first (most likely to fail)
-					if (static_cast<uint32_t>(static_cast<int32_t>(cpos.z) - minRangeZ) > depth) {
-						continue;
-					}
-
-					const int_fast16_t offsetZ = Position::getOffsetZ(centerPos, cpos);
-					const int32_t adjustedX = cpos.x - offsetZ;
-					const int32_t adjustedY = cpos.y - offsetZ;
-
-					// Check X and Y ranges
-					if (static_cast<uint32_t>(adjustedX - min_x) <= width && static_cast<uint32_t>(adjustedY - min_y) <= height) {
-						spectators.emplace_back(creature);
+					if (static_cast<uint32_t>(static_cast<int32_t>(cpos.z) - minRangeZ) <= depth) {
+						const int_fast16_t offsetZ = Position::getOffsetZ(centerPos, cpos);
+						if (static_cast<uint32_t>(cpos.x - offsetZ - min_x) <= width && static_cast<uint32_t>(cpos.y - offsetZ - min_y) <= height) {
+							spectators.emplace_back(creature);
+						}
 					}
 				}
 				sectorE = sectorE->sectorE;


### PR DESCRIPTION
This PR fixes getSpectators calculations and improve thread pool

- Composition vs. Inheritance: uses composition (std::unique_ptr), which allows for better control over the pool's lifetime (such as resetting memory on shutdown) and avoids exposing unnecessary internal methods.

- Thread Safety: uses std::atomic<bool> for the stopped flag, preventing race conditions that existed in its original implementation.

- Clean Shutdown: ensures that the pool is destroyed and system signals are correctly reset upon shutdown.