### PR TITLE
fix: updates to questtrack and network functions and emoteSpells config

### DIFF
--- a/data/modules/scripts/questtrack/questtrack.lua
+++ b/data/modules/scripts/questtrack/questtrack.lua
@@ -1,7 +1,21 @@
 function onRecvbyte(player, msg, byte)
 	if byte == 0xD0 then
+		local function getRemainingBytes()
+			return msg:getLength() - (msg:getBufferPosition() - 7)
+		end
+
+		if getRemainingBytes() < 3 then
+			return
+		end
+
 		local quests = {}
 		local missions = msg:getByte()
+
+		local requiredBytes = (missions * 2) + 2
+		if getRemainingBytes() < requiredBytes then
+			return
+		end
+
 		for i = 1, missions do
 			quests[#quests + 1] = msg:getU16()
 		end

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -10124,7 +10124,7 @@ bool Player::saySpell(SpeakClasses type, const std::string &text, bool isGhostMo
 				if (emoteSpellsEnabled) {
 					tmpPlayer->sendCreatureSay(static_self_cast<Player>(), TALKTYPE_MONSTER_SAY, text, pos);
 				} else {
-					tmpPlayer->sendCreatureSay(static_self_cast<Player>(), TALKTYPE_SPELL_USE, text, pos);
+					tmpPlayer->sendCreatureSay(static_self_cast<Player>(), TALKTYPE_SAY, text, pos);
 				}
 			}
 		}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -10117,10 +10117,11 @@ bool Player::saySpell(SpeakClasses type, const std::string &text, bool isGhostMo
 	}
 
 	// Send to client
+	bool emoteSpellsEnabled = g_configManager().getBoolean(EMOTE_SPELLS);
 	for (const auto &spectator : spectators) {
 		if (const auto &tmpPlayer = spectator->getPlayer()) {
 			if (!isGhostMode || tmpPlayer->canSeeCreature(static_self_cast<Player>())) {
-				if (g_configManager().getBoolean(EMOTE_SPELLS)) {
+				if (emoteSpellsEnabled) {
 					tmpPlayer->sendCreatureSay(static_self_cast<Player>(), TALKTYPE_MONSTER_SAY, text, pos);
 				} else {
 					tmpPlayer->sendCreatureSay(static_self_cast<Player>(), TALKTYPE_SPELL_USE, text, pos);

--- a/src/lua/functions/core/network/network_message_functions.cpp
+++ b/src/lua/functions/core/network/network_message_functions.cpp
@@ -33,6 +33,8 @@ void NetworkMessageFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "NetworkMessage", "getU64", NetworkMessageFunctions::luaNetworkMessageGetU64);
 	Lua::registerMethod(L, "NetworkMessage", "getString", NetworkMessageFunctions::luaNetworkMessageGetString);
 	Lua::registerMethod(L, "NetworkMessage", "getPosition", NetworkMessageFunctions::luaNetworkMessageGetPosition);
+	Lua::registerMethod(L, "NetworkMessage", "getLength", NetworkMessageFunctions::luaNetworkMessageGetLength);
+	Lua::registerMethod(L, "NetworkMessage", "getBufferPosition", NetworkMessageFunctions::luaNetworkMessageGetBufferPosition);
 
 	Lua::registerMethod(L, "NetworkMessage", "addByte", NetworkMessageFunctions::luaNetworkMessageAddByte);
 	Lua::registerMethod(L, "NetworkMessage", "addU16", NetworkMessageFunctions::luaNetworkMessageAddU16);
@@ -119,6 +121,28 @@ int NetworkMessageFunctions::luaNetworkMessageGetPosition(lua_State* L) {
 	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
 	if (message) {
 		Lua::pushPosition(L, message->getPosition());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int NetworkMessageFunctions::luaNetworkMessageGetLength(lua_State* L) {
+	// networkMessage:getLength()
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	if (message) {
+		lua_pushnumber(L, message->getLength());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int NetworkMessageFunctions::luaNetworkMessageGetBufferPosition(lua_State* L) {
+	// networkMessage:getBufferPosition()
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	if (message) {
+		lua_pushnumber(L, message->getBufferPosition());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/core/network/network_message_functions.hpp
+++ b/src/lua/functions/core/network/network_message_functions.hpp
@@ -30,6 +30,8 @@ private:
 	static int luaNetworkMessageGetU64(lua_State* L);
 	static int luaNetworkMessageGetString(lua_State* L);
 	static int luaNetworkMessageGetPosition(lua_State* L);
+	static int luaNetworkMessageGetLength(lua_State* L);
+	static int luaNetworkMessageGetBufferPosition(lua_State* L);
 
 	static int luaNetworkMessageAddByte(lua_State* L);
 	static int luaNetworkMessageAddU16(lua_State* L);


### PR DESCRIPTION
## Fixes

### 1. Protocol desynchronization on diagonal movement
Fixed black border bug during diagonal movement. The protocol wasn't sending correct map description on login, causing client desync when using numpad diagonal keys.

**Commit:** ecdb60b

---

### 2. emoteSpells config now correctly shows yellow text when disabled

Previously, when `emoteSpells` was set to `false` in config.lua, spell text still appeared in orange color. This was caused using `TALKTYPE_SPELL_USE` which OTClient treats the same as `TALKTYPE_MONSTER_SAY` (both render as orange).

**Solution:** Changed to use `TALKTYPE_SAY` when emoteSpells is false, which correctly renders as yellow text in OTClient.

**Behavior:**
- `emoteSpells = true`: Orange emote above character (TALKTYPE_MONSTER_SAY)
- `emoteSpells = false`: Yellow text in chat (TALKTYPE_SAY)

---

## Testing
- [x] Tested diagonal movement with numpad keys
- [x] Tested emoteSpells = true (orange text)
- [x] Tested emoteSpells = false (yellow text)