### PR TITLE
Fix: To Outfox a Fox Questlog

### DIFF
--- a/data-global/lib/core/quests.lua
+++ b/data-global/lib/core/quests.lua
@@ -4675,7 +4675,7 @@ if not Quests then
 				},
 				[14] = {
 					name = "To Outfox a Fox",
-					storageId = Storage.Quest.U8_1.ToOutfoxAFoxQuest,
+					storageId = Storage.Quest.U8_1.ToOutfoxAFoxQuest.Questline,
 					missionId = 10432,
 					startValue = 1,
 					endValue = 2,


### PR DESCRIPTION
Adding missing .Questline in the quests.lua in order to display correctly in the questlog.