### PR TITLE
Fix: Banshee Quest Corpse

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -7916,7 +7916,7 @@
 		<attribute key="charges" value="1" />
 		<attribute key="weight" value="210" />
 	</item>
-	<item id="3204" article="a" name="dead human" />
+	<item id="3204" name="your own dead body" />
 	<item id="3205" article="a" name="family brooch">
 		<attribute key="primarytype" value="quest items" />
 		<attribute key="description" value="You see the familyname Windtrouser engraved on this brooch" />


### PR DESCRIPTION
Correct description for item ID.
<img width="362" height="418" alt="image" src="https://github.com/user-attachments/assets/f739d394-437c-479b-918c-3f65da81e746" />
Note:
ID: 3204 with Unique ID: 5016 at Position: (32576, 32216, 15) Scheduled to be replaced for ID 4240 in map and updated in chests.lua at next map update:
	-- Key 3667
	[5016] = {
		isKey = true,
		itemId = 4240,
		itemPos = { x = 32576, y = 32216, z = 15 },
		reward = { { 2969, 1 } },
		storage = Storage.Quest.Key.ID3667,
	},