### PR TITLE
fix: damage reflection calculations for secondary combat type

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7107,7 +7107,7 @@ bool Game::combatBlockHit(CombatDamage &damage, const std::shared_ptr<Creature> 
 					}
 					damageReflected.extension = true;
 					damageReflected.exString += " (damage reflection)";
-					damageReflectedParams.combatType = damage.primary.type;
+					damageReflectedParams.combatType = damage.secondary.type;
 					damageReflectedParams.aggressive = true;
 					canReflect = true;
 				}
@@ -7141,13 +7141,13 @@ bool Game::combatBlockHit(CombatDamage &damage, const std::shared_ptr<Creature> 
 		damage.secondary.value = -damage.secondary.value;
 		InternalGame::sendBlockEffect(secondaryBlockType, damage.secondary.type, target->getPosition(), attacker);
 
-		if (!damage.extension && attacker && target->getMonster()) {
+		if (!damage.extension && attacker) {
 			int32_t secondaryReflectPercent = target->getReflectPercent(damage.secondary.type, true);
 			int32_t secondaryReflectFlat = target->getReflectFlat(damage.secondary.type, true);
 			if (secondaryReflectPercent > 0 || secondaryReflectFlat > 0) {
 				if (!canReflect) {
 					int32_t reflectFlat = -static_cast<int32_t>(secondaryReflectFlat);
-					int32_t reflectPercent = std::ceil(damage.primary.value * secondaryReflectPercent / 100.);
+					int32_t reflectPercent = std::ceil(damage.secondary.value * secondaryReflectPercent / 100.);
 					int32_t reflectLimit = std::ceil(attacker->getMaxHealth() * 0.01);
 					damageReflected.primary.value = std::max(-reflectLimit, reflectFlat + reflectPercent);
 					damageReflected.primary.type = damage.secondary.type;
@@ -7156,12 +7156,12 @@ bool Game::combatBlockHit(CombatDamage &damage, const std::shared_ptr<Creature> 
 					}
 					damageReflected.extension = true;
 					damageReflected.exString += " (damage reflection)";
-					damageReflectedParams.combatType = damage.primary.type;
+					damageReflectedParams.combatType = damage.secondary.type;
 					damageReflectedParams.aggressive = true;
 					canReflect = true;
 				} else {
 					damageReflected.secondary.type = damage.secondary.type;
-					damageReflected.primary.value = std::ceil(damage.secondary.value * secondaryReflectPercent / 100.) + std::max(-static_cast<int32_t>(std::ceil(attacker->getMaxHealth() * 0.01)), std::max(damage.secondary.value, -(static_cast<int32_t>(secondaryReflectFlat))));
+					damageReflected.secondary.value = std::max(-static_cast<int32_t>(std::ceil(attacker->getMaxHealth() * 0.01)), -static_cast<int32_t>(secondaryReflectFlat) + static_cast<int32_t>(std::ceil(damage.secondary.value * secondaryReflectPercent / 100.)));
 				}
 			}
 		}
@@ -7178,7 +7178,7 @@ bool Game::combatBlockHit(CombatDamage &damage, const std::shared_ptr<Creature> 
 		if (!damage.exString.empty()) {
 			damage.exString += ", ";
 		}
-		damage.exString += "active elemental resiliance";
+		damage.exString += "active elemental resilience";
 	}
 
 	if (damageIncreaseMessage) {


### PR DESCRIPTION
## Description

Fixes three bugs in the secondary damage reflection block inside `Game::combatBlockHit`.

Related to #653

## Bugs Fixed

### Bug 1 — Wrong source value in `!canReflect` branch
`reflectPercent` was computed using `damage.primary.value` instead of `damage.secondary.value`, causing the secondary reflect to be based on the wrong damage number.

### Bug 2 — Wrong `combatType` in params (`!canReflect` branch)
`damageReflectedParams.combatType` was set to `damage.primary.type` instead of `damage.secondary.type`, dispatching the reflected secondary damage as the wrong combat type.

### Bug 3 — Wrong target field and broken formula (`canReflect` branch)
The secondary reflected value was written to `damageReflected.primary.value` (overwriting the primary reflect) instead of `damageReflected.secondary.value`. The formula also used a broken nested `std::max` instead of applying flat + percent additively with the proper 1% health cap.

## Credits

Thanks to @Jattartajjar and @iloveShaders for identifying and reporting these issues.