### PR TITLE
update: advanced party protection

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -349,6 +349,10 @@ function Player:CreateFamiliarSpell(spellId)
 
 	local createdSuccessfully = self:createFamiliar(familiarName, summonDuration)
 	if createdSuccessfully then
+		local summons = self:getSummons()
+		for _, summon in ipairs(summons) do
+			summon:registerEvent("PartyProtection")
+		end
 		condition:setTicks(1000 * cooldown / configManager.getFloat(configKeys.RATE_SPELL_COOLDOWN))
 		self:addCondition(condition)
 		return true

--- a/data/scripts/creaturescripts/player/party_protection.lua
+++ b/data/scripts/creaturescripts/player/party_protection.lua
@@ -15,6 +15,7 @@ local function getPlayerMaster(creature)
 	end
 	return nil
 end
+
 function partyProtection.onHealthChange(creature, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
 	if not enabled then
 		return primaryDamage, primaryType, secondaryDamage, secondaryType
@@ -24,7 +25,7 @@ function partyProtection.onHealthChange(creature, attacker, primaryDamage, prima
 	end
 	local sourcePlayer = getPlayerMaster(attacker)
 	if not sourcePlayer then
-		return primaryDamage, primaryType, secondaryDamage, secondaryDamage, secondaryType
+		return primaryDamage, primaryType, secondaryDamage, secondaryType
 	end
 	local targetPlayer = getPlayerMaster(creature)
 	if not targetPlayer then
@@ -33,11 +34,19 @@ function partyProtection.onHealthChange(creature, attacker, primaryDamage, prima
 	if primaryType == COMBAT_HEALING or secondaryType == COMBAT_HEALING then
 		return primaryDamage, primaryType, secondaryDamage, secondaryType
 	end
+	if sourcePlayer:getId() == targetPlayer:getId() then
+		return 0, primaryType, 0, secondaryType
+	end
 	local party1 = sourcePlayer:getParty()
 	local party2 = targetPlayer:getParty()
-	if party1 and party2 and party1 == party2 then
-		return 0, primaryType, 0, secondaryType
+	if party1 and party2 then
+		local leader1 = party1:getLeader()
+		local leader2 = party2:getLeader()
+		if leader1 and leader2 and leader1:getId() == leader2:getId() then
+			return 0, primaryType, 0, secondaryType
+		end
 	end
 	return primaryDamage, primaryType, secondaryDamage, secondaryType
 end
+
 partyProtection:register()


### PR DESCRIPTION
This update now grants protection among players and their party members summons.

For example, in a war, your attacks won't damage your friend's summons, useful in team hunts too.

Note for custom scripts: Remember, you need to register the event when you create a summon in a custom code like this: summon:registerEvent("PartyProtection")