### PR TITLE
fix: Consume Amulet of Loss when no blessing used

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -4185,8 +4185,13 @@ void Player::death(const std::shared_ptr<Creature> &lastHitCreature) {
 
 			const auto playerSkull = getSkull();
 			bool hasSkull = (playerSkull == Skulls_t::SKULL_RED || playerSkull == Skulls_t::SKULL_BLACK);
+			const auto &amulet = getInventoryItem(CONST_SLOT_NECKLACE);
+			const bool usingAol = amulet && amulet->getID() == ITEM_AMULETOFLOSS;
+			const bool twistProtectsAol = !hasSkull && pvpDeath && hasBlessing(1);
+			bool consumedBlessingProtection = false;
 			uint8_t maxBlessing = 8;
-			if (!hasSkull && pvpDeath && hasBlessing(1)) {
+			if (twistProtectsAol) {
+				consumedBlessingProtection = true;
 				auto storeCount = getBlessingCount(1, true);
 				if (storeCount > 0) {
 					auto currentStore = kv()->scoped("summary")->scoped("blessings")->scoped(fmt::format("{}", 1))->get("amount");
@@ -4201,15 +4206,21 @@ void Player::death(const std::shared_ptr<Creature> &lastHitCreature) {
 				for (int i = 2; i <= maxBlessing; i++) {
 					auto storeCount = getBlessingCount(i, true);
 					if (storeCount > 0) {
+						consumedBlessingProtection = true;
 						auto currentStore = kv()->scoped("summary")->scoped("blessings")->scoped(fmt::format("{}", i))->get("amount");
 						if (currentStore) {
 							auto newAmount = std::max(0, static_cast<int>(currentStore->getNumber()) - 1);
 							kv()->scoped("summary")->scoped("blessings")->scoped(fmt::format("{}", i))->set("amount", newAmount);
 						}
-					} else {
+					} else if (hasBlessing(i)) {
+						consumedBlessingProtection = true;
 						removeBlessing(i, 1);
 					}
 				}
+			}
+
+			if (usingAol && !consumedBlessingProtection) {
+				g_game().internalRemoveItem(amulet);
 			}
 		}
 		sendTextMessage(MESSAGE_EVENT_ADVANCE, blessOutput.str());


### PR DESCRIPTION
Player::death now checks the necklace slot for an Amulet of Loss and tracks whether any blessing protection was consumed (consumedBlessingProtection).

The previous blessing-check conditional was refactored into twistProtectsAol and the code marks consumedBlessingProtection when decrementing stored blessing counts or removing blessings.

If the player is using an Amulet of Loss and no blessing protection was consumed during death handling, the amulet is removed via g_game().internalRemoveItem(amulet). This ensures the amulet is only consumed when no blessing prevented item loss.


fixes: https://github.com/zimbadev/crystalserver/issues/678