### PR TITLE
fix: Prefer lower denominations when removing money

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2764,9 +2764,17 @@ bool Game::removeMoney(const std::shared_ptr<Cylinder> &cylinder, uint64_t money
 		return false;
 	}
 
-	// Sort money items descending by worth to minimize item operations.
+	// Prefer lower denominations first so routine payments do not consume
+	// crystal/platinum coins when gold coins already cover the cost.
 	std::sort(moneyItems.begin(), moneyItems.end(), [](const auto &a, const auto &b) {
-		return a.first > b.first;
+		const uint32_t aCount = std::max<uint32_t>(1, a.second->getItemCount());
+		const uint32_t bCount = std::max<uint32_t>(1, b.second->getItemCount());
+		const uint32_t aUnitWorth = a.first / aCount;
+		const uint32_t bUnitWorth = b.first / bCount;
+		if (aUnitWorth == bUnitWorth) {
+			return a.first < b.first;
+		}
+		return aUnitWorth < bUnitWorth;
 	});
 
 	for (const auto &entry : moneyItems) {


### PR DESCRIPTION
Change removeMoney sorting so lower-denomination coin stacks are preferred first instead of sorting by total worth descending. The comparator now computes a per-item unit worth (total worth / max(1, itemCount)) to avoid divide-by-zero and sorts by unit worth ascending, with a tie-breaker on total worth. This prevents routine payments from consuming high-value coins (e.g., crystal/platinum) when smaller coins (gold) can cover the cost.