### PR TITLE
fix: exiva restrictions

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -12710,9 +12710,12 @@ void Player::removeEquippedWeaponProficiency(const uint16_t itemId) {
 }
 
 bool Player::canExiva(const std::string &spellParam) const {
-	if (g_game().getWorldType() != WORLDTYPE_OPTIONAL && !g_configManager().getBoolean(EXIVA_RESTRICTIONS_ONLY_OPTIONAL_WORLDS)) {
-		return true;
-	}
+    const bool restrictOnlyOptional = g_configManager().getBoolean(EXIVA_RESTRICTIONS_ONLY_OPTIONAL_WORLDS);
+    const bool isOptionalWorld = g_game().getWorldType() == WORLDTYPE_OPTIONAL;
+
+    if (restrictOnlyOptional && !isOptionalWorld) {
+        return true;
+    }
 
 	const auto &targetPlayer = g_game().getPlayerByName(spellParam);
 	if (!targetPlayer) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -12710,12 +12710,12 @@ void Player::removeEquippedWeaponProficiency(const uint16_t itemId) {
 }
 
 bool Player::canExiva(const std::string &spellParam) const {
-    const bool restrictOnlyOptional = g_configManager().getBoolean(EXIVA_RESTRICTIONS_ONLY_OPTIONAL_WORLDS);
-    const bool isOptionalWorld = g_game().getWorldType() == WORLDTYPE_OPTIONAL;
+	const bool restrictOnlyOptional = g_configManager().getBoolean(EXIVA_RESTRICTIONS_ONLY_OPTIONAL_WORLDS);
+	const bool isOptionalWorld = g_game().getWorldType() == WORLDTYPE_OPTIONAL;
 
-    if (restrictOnlyOptional && !isOptionalWorld) {
-        return true;
-    }
+	if (restrictOnlyOptional && !isOptionalWorld) {
+		return true;
+	}
 
 	const auto &targetPlayer = g_game().getPlayerByName(spellParam);
 	if (!targetPlayer) {


### PR DESCRIPTION
The restrictions update is just fine, but u guys forget about the retro pvp, so when it's turned on in this mode the spell doesn't work. This little fix ask for both conditions so it doesn't break retropvp exiva magic spell.