### PR TITLE
fix: Update online time calc and persist lastlogin

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2954,13 +2954,13 @@ bool Player::closeShopWindow() {
 }
 
 void Player::onWalk(Direction &dir) {
-    if (hasCondition(CONDITION_PARALYZE)) {
-        uint32_t delay = g_configManager().getNumber(PARALYZE_DELAY_INTERVAL);
-        setNextAction(OTSYS_TIME() + delay);
-        lastWalking = OTSYS_TIME() + delay;
-        return;
-    }
-	
+	if (hasCondition(CONDITION_PARALYZE)) {
+		uint32_t delay = g_configManager().getNumber(PARALYZE_DELAY_INTERVAL);
+		setNextAction(OTSYS_TIME() + delay);
+		lastWalking = OTSYS_TIME() + delay;
+		return;
+	}
+
 	if (hasCondition(CONDITION_FEARED)) {
 		const Position pos = getNextPosition(dir, getPosition());
 

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -194,6 +194,18 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	// First, an UPDATE query to write the player itself
 	query.str("");
 	query << "UPDATE `players` SET ";
+
+	time_t updatedLastLoginSaved = player->lastLoginSaved;
+	int64_t onlineTimeDelta = 0;
+	bool advanceLastLoginSaved = false;
+	if (!player->isOffline() && player->lastLoginSaved != 0) {
+		const auto now = std::chrono::system_clock::now();
+		const auto lastLoginSaved = std::chrono::system_clock::from_time_t(player->lastLoginSaved);
+		onlineTimeDelta = std::max<int64_t>(0, std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count());
+		updatedLastLoginSaved = std::chrono::system_clock::to_time_t(now);
+		advanceLastLoginSaved = true;
+	}
+
 	query << "`name` = " << db.escapeString(player->name) << ",";
 	query << "`level` = " << player->level << ",";
 	query << "`group_id` = " << player->group->id << ",";
@@ -239,8 +251,8 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	query << "`cap` = " << (player->capacity / 100) << ",";
 	query << "`sex` = " << static_cast<uint16_t>(player->sex) << ",";
 
-	if (player->lastLoginSaved != 0) {
-		query << "`lastlogin` = " << player->lastLoginSaved << ",";
+	if (updatedLastLoginSaved != 0) {
+		query << "`lastlogin` = " << updatedLastLoginSaved << ",";
 	}
 
 	if (player->lastIP != 0) {
@@ -347,9 +359,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	query << "`weapon_proficiencies` = " << db.escapeBlob(proficiencyData, static_cast<uint32_t>(proficiencySize)) << ",";
 
 	if (!player->isOffline()) {
-		auto now = std::chrono::system_clock::now();
-		auto lastLoginSaved = std::chrono::system_clock::from_time_t(player->lastLoginSaved);
-		query << "`onlinetime` = `onlinetime` + " << std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count() << ",";
+		query << "`onlinetime` = `onlinetime` + " << onlineTimeDelta << ",";
 	}
 
 	for (int i = 1; i <= 8; i++) {
@@ -360,6 +370,10 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 
 	if (!db.executeQuery(query.str())) {
 		return false;
+	}
+
+	if (advanceLastLoginSaved) {
+		player->lastLoginSaved = updatedLastLoginSaved;
 	}
 	return true;
 }


### PR DESCRIPTION
`IOLoginDataSave::savePlayerFirst` accumulates online time with

```cpp
onlinetime = onlinetime + (now - player->lastLoginSaved)
```

Compute onlineTimeDelta once (when player is online and lastLoginSaved != 0), use an updatedLastLoginSaved timestamp in the UPDATE query, and increment onlinetime by the computed delta instead of recalculating now inline.

 After a successful DB save, advance the player's in-memory lastLoginSaved to the new timestamp.
This prevents incorrect/negative deltas, avoids repeated now() calls, and keeps DB and in-memory last-login state consistent.