### PR TITLE
improve: Allow gold pouch reordering in store inbox

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2954,13 +2954,13 @@ bool Player::closeShopWindow() {
 }
 
 void Player::onWalk(Direction &dir) {
-    if (hasCondition(CONDITION_PARALYZE)) {
-        uint32_t delay = g_configManager().getNumber(PARALYZE_DELAY_INTERVAL);
-        setNextAction(OTSYS_TIME() + delay);
-        lastWalking = OTSYS_TIME() + delay;
-        return;
-    }
-	
+	if (hasCondition(CONDITION_PARALYZE)) {
+		uint32_t delay = g_configManager().getNumber(PARALYZE_DELAY_INTERVAL);
+		setNextAction(OTSYS_TIME() + delay);
+		lastWalking = OTSYS_TIME() + delay;
+		return;
+	}
+
 	if (hasCondition(CONDITION_FEARED)) {
 		const Position pos = getNextPosition(dir, getPosition());
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1948,12 +1948,24 @@ void Game::playerMoveItem(const std::shared_ptr<Player> &player, const Position 
 		player->stowItem(item, count, false);
 		return;
 	}
-	if (!item->isPushable() || item->hasAttribute(ItemAttribute_t::UNIQUEID)) {
+
+	const auto fromContainer = fromCylinder->getContainer();
+	const auto toContainer = toCylinder->getContainer();
+	const bool fromStoreInbox = fromContainer && fromContainer->getRootContainer() && fromContainer->getRootContainer()->isStoreInbox();
+	const bool toStoreInbox = toContainer && toContainer->getRootContainer() && toContainer->getRootContainer()->isStoreInbox();
+	const bool isGoldPouchStoreInboxReorder = item->getID() == ITEM_GOLD_POUCH && fromStoreInbox && toStoreInbox;
+
+	uint32_t moveFlags = 0;
+	if (isGoldPouchStoreInboxReorder) {
+		moveFlags |= FLAG_IGNORENOTMOVABLE;
+	}
+
+	if ((!item->isPushable() && !isGoldPouchStoreInboxReorder) || item->hasAttribute(ItemAttribute_t::UNIQUEID)) {
 		player->sendCancelMessage(RETURNVALUE_NOTMOVABLE);
 		return;
 	}
 
-	const auto ret = internalMoveItem(fromCylinder, toCylinder, toIndex, item, count, nullptr, 0, player);
+	const auto ret = internalMoveItem(fromCylinder, toCylinder, toIndex, item, count, nullptr, moveFlags, player);
 	if (ret != RETURNVALUE_NOERROR) {
 		player->sendCancelMessage(ret);
 	} else if (toCylinder->getContainer() && fromCylinder->getContainer() && fromCylinder->getContainer()->countsToLootAnalyzerBalance() && toCylinder->getContainer()->getTopParent() == player) {
@@ -1977,8 +1989,13 @@ ReturnValue Game::checkMoveItemToCylinder(const std::shared_ptr<Player> &player,
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
+	const auto fromContainer = fromCylinder->getContainer();
+	const bool fromStoreInbox = fromContainer && fromContainer->getRootContainer() && fromContainer->getRootContainer()->isStoreInbox();
+
 	if (std::shared_ptr<Container> toCylinderContainer = toCylinder->getContainer()) {
 		auto containerID = toCylinderContainer->getID();
+		const auto rootToContainer = toCylinderContainer->getRootContainer();
+		const bool toStoreInbox = rootToContainer && rootToContainer->isStoreInbox();
 
 		// check the store inbox index if gold pouch forces it as containerID
 		if (containerID == ITEM_STORE_INBOX) {
@@ -1990,7 +2007,24 @@ ReturnValue Game::checkMoveItemToCylinder(const std::shared_ptr<Player> &player,
 
 		const auto containerToStow = isTryingToStow(toPos, toCylinder);
 
+		if (toStoreInbox && !containerToStow) {
+			const bool isGoldPouch = item->getID() == ITEM_GOLD_POUCH;
+			const bool canMoveInStoreInbox = item->canBeMovedToStore() || isGoldPouch;
+			if (!canMoveInStoreInbox) {
+				return RETURNVALUE_NOTBOUGHTINSTORE;
+			}
+
+			// Store Inbox accepts only items already inside it (internal reordering).
+			if (!fromStoreInbox) {
+				return RETURNVALUE_NOTBOUGHTINSTORE;
+			}
+		}
+
 		if (containerID == ITEM_GOLD_POUCH && !containerToStow) {
+			if (!fromStoreInbox) {
+				return RETURNVALUE_NOTBOUGHTINSTORE;
+			}
+
 			if (g_configManager().getBoolean(TOGGLE_GOLD_POUCH_QUICKLOOT_ONLY)) {
 				return RETURNVALUE_CONTAINERNOTENOUGHROOM;
 			}
@@ -1999,11 +2033,6 @@ ReturnValue Game::checkMoveItemToCylinder(const std::shared_ptr<Player> &player,
 
 			if (!allowAnything && item->getID() != ITEM_GOLD_COIN && item->getID() != ITEM_PLATINUM_COIN && item->getID() != ITEM_CRYSTAL_COIN) {
 				return RETURNVALUE_ITEMCANNOTBEMOVEDPOUCH;
-			}
-
-			// prevent move up from ponch to store inbox.
-			if (!item->canBeMovedToStore() && fromCylinder->getContainer() && fromCylinder->getContainer()->getID() == ITEM_GOLD_POUCH) {
-				return RETURNVALUE_NOTBOUGHTINSTORE;
 			}
 
 			return RETURNVALUE_NOERROR;


### PR DESCRIPTION
Enable internal reordering of the gold pouch within store inboxes. playerMoveItem now detects store-inbox source/target and sets a move flag (FLAG_IGNORENOTMOVABLE) for gold-pouch reorders so the pouch can be moved despite not being pushable; this flag is passed into internalMoveItem. 

checkMoveItemToCylinder enforces store inbox rules: only items that can be moved to store (or the gold pouch) are allowed into the inbox, and the inbox only accepts internal reordering (moves originating from the store inbox). Existing UNIQUEID checks remain, and moving items into the store inbox from outside is still prevented.