### PR TITLE
fix: Update Elemental Spheres and machine item IDs

### DIFF
--- a/data-global/scripts/actions/other/enchanting.lua
+++ b/data-global/scripts/actions/other/enchanting.lua
@@ -47,7 +47,7 @@ function enchanting.onUse(player, item, fromPosition, target, toPosition, isHotk
 	if table.contains({ 33268, 33269 }, toPosition.x) and toPosition.y == 31830 and toPosition.z == 10 and player:getStorageValue(Storage.Quest.U8_2.ElementalSpheres.QuestLine) > 0 then
 		if not table.contains(spheres[item.itemid], player:getVocation():getBaseId()) then
 			return false
-		elseif table.contains({ 842, 843 }, target.itemid) then
+		elseif table.contains({ 846, 847 }, target.itemid) then
 			player:say("Turn off the machine first.", TALKTYPE_MONSTER_SAY)
 			return true
 		else

--- a/data-global/scripts/quests/elemental_spheres/actions_machine1.lua
+++ b/data-global/scripts/quests/elemental_spheres/actions_machine1.lua
@@ -29,7 +29,7 @@ function elementalSpheresMachine1.onUse(player, item, fromPosition, target, toPo
 		toPosition.x = toPosition.x + (item.itemid == 846 and 1 or -1)
 		local tile = toPosition:getTile()
 		if tile then
-			local thing = tile:getItemById(item.itemid == 842 and 843 or 842)
+			local thing = tile:getItemById(item.itemid == 846 and 847 or 846)
 			if thing then
 				thing:transform(thing.itemid - 4)
 			end
@@ -39,5 +39,5 @@ function elementalSpheresMachine1.onUse(player, item, fromPosition, target, toPo
 	return true
 end
 
-elementalSpheresMachine1:id(842, 843)
+elementalSpheresMachine1:id(842, 843, 846, 847)
 elementalSpheresMachine1:register()

--- a/data-global/scripts/quests/elemental_spheres/actions_machine2.lua
+++ b/data-global/scripts/quests/elemental_spheres/actions_machine2.lua
@@ -14,7 +14,7 @@ function elementalSpheresMachine2.onUse(player, item, fromPosition, target, toPo
 		player:say("ON", TALKTYPE_MONSTER_SAY, false, player, toPosition)
 	else
 		toPosition.y = toPosition.y + (item.itemid == 848 and 1 or -1)
-		local machineItem = Tile(toPosition):getItemById(item.itemid == 848 and 845 or 849)
+		local machineItem = Tile(toPosition):getItemById(item.itemid == 848 and 849 or 848)
 		if machineItem then
 			machineItem:transform(machineItem.itemid - 4)
 		end

--- a/data-global/scripts/quests/elemental_spheres/actions_soils2.lua
+++ b/data-global/scripts/quests/elemental_spheres/actions_soils2.lua
@@ -1,8 +1,8 @@
 local spheres = {
-	[8300] = VOCATION.BASE_ID.PALADIN,
-	[8304] = VOCATION.BASE_ID.SORCERER,
-	[8305] = VOCATION.BASE_ID.DRUID,
-	[8306] = VOCATION.BASE_ID.KNIGHT,
+	[942] = VOCATION.BASE_ID.PALADIN,
+	[946] = VOCATION.BASE_ID.SORCERER,
+	[947] = VOCATION.BASE_ID.DRUID,
+	[948] = VOCATION.BASE_ID.KNIGHT,
 }
 
 local globalTable = {
@@ -14,7 +14,7 @@ local globalTable = {
 
 local elementalSpheresSoils2 = Action()
 function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not table.contains({ 7917, 7918, 7913, 7914 }, target.itemid) then
+	if not table.contains({ 842, 843, 844, 845, 846, 847, 848, 849 }, target.itemid) then
 		return false
 	end
 
@@ -22,20 +22,20 @@ function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosi
 		return false
 	end
 
-	if not table.contains(spheres[item.itemid], player:getVocation():getBaseId()) then
+	if spheres[item.itemid] ~= player:getVocation():getBaseId() then
 		return false
 	end
 
-	if table.contains({ 7917, 7918 }, target.itemid) then
+	if table.contains({ 846, 847, 848, 849 }, target.itemid) then
 		player:say("Turn off the machine first.", TALKTYPE_MONSTER_SAY)
 		return true
 	end
 
 	toPosition:sendMagicEffect(CONST_ME_PURPLEENERGY)
-	Game.setStorageValue(globalTable[player:getVocation():getBase():getId()], 1)
+	Game.setStorageValue(globalTable[player:getVocation():getBaseId()], 1)
 	item:remove(1)
 	return true
 end
 
-elementalSpheresSoils2:id(8300, 8304, 8305, 8306)
+elementalSpheresSoils2:id(942, 946, 947, 948)
 elementalSpheresSoils2:register()


### PR DESCRIPTION
Adjust item ID checks and mappings for the Elemental Spheres quest: replace old soil sphere IDs with new ones (942, 946, 947, 948), expand and correct allowed machine item ID ranges, and update machine toggle checks in enchanting and machine actions. Fix machine1 registration to include additional IDs and correct item lookups in machine1/machine2. Also simplify the vocation check and correct storage key usage (getBaseId) when setting quest state.