### PR TITLE
fix: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -229,7 +229,8 @@ std::string generateToken(const std::string &key, uint32_t ticks) {
 
 	// hmac key pad generation
 	std::string iKeyPad(64, 0x36), oKeyPad(64, 0x5C);
-	for (uint8_t i = 0; i < key.length(); ++i) {
+	const std::string::size_type keyPadLimit = std::min(key.length(), iKeyPad.length());
+	for (std::string::size_type i = 0; i < keyPadLimit; ++i) {
 		iKeyPad[i] ^= key[i];
 		oKeyPad[i] ^= key[i];
 	}

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -243,7 +243,7 @@ std::string generateToken(const std::string &key, uint32_t ticks) {
 	message.assign(transformToSHA1(iKeyPad));
 
 	// hmac concat outer pad with message, conversion from hex to int needed
-	for (uint8_t i = 0; i < message.length(); i += 2) {
+	for (std::string::size_type i = 0; i < message.length(); i += 2) {
 		oKeyPad.push_back(static_cast<char>(std::stol(message.substr(i, 2), nullptr, 16)));
 	}
 


### PR DESCRIPTION
Use a loop counter type that is at least as wide as `message.length()`’s type. The best fix is to change the loop index at line 246 from `uint8_t` to `std::string::size_type` (or `size_t`) so both sides of the comparison are width-compatible and cannot wrap at 255.

In a loop condition, comparison of a value of a narrow type with a value of a wide type may result in unexpected behavior if the wider value is sufficiently large (or small). This is because the narrower value may overflow. This can lead to an infinite loop.
