### PR TITLE
fix: gem index

### DIFF
--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -1163,9 +1163,9 @@ PlayerWheelGem &PlayerWheel::getGem(const std::string &uuid) {
 }
 
 uint16_t PlayerWheel::getGemIndex(const std::string &uuid) const {
-	for (uint16_t i = 0; i < m_revealedGems.size(); ++i) {
+	for (size_t i = 0; i < m_revealedGems.size(); ++i) {
 		if (m_revealedGems[i].uuid == uuid) {
-			return i;
+			return static_cast<uint16_t>(i);
 		}
 	}
 	g_logger().error("[{}] Failed to find gem with uuid {}", __FUNCTION__, uuid);


### PR DESCRIPTION
Use the container’s native index type in the loop (`size_t` or `std::vector<...>::size_type`) so both sides of the comparison have compatible width.

Best minimal fix (without changing behavior): in `src/creatures/players/wheel/player_wheel.cpp`, inside `PlayerWheel::getGemIndex`, change the loop variable type from `uint16_t` to `size_t`, and cast on return to keep the function signature unchanged (`uint16_t`). This removes the narrow/wide comparison in the loop condition and preserves existing API behavior.

