### PR TITLE
fix: Add memcpy checks and XTEA error logging

### DIFF
--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -223,7 +223,7 @@ void Connection::parseHeader(const std::error_code &error) {
 	}
 
 	uint16_t size = m_msg.getLengthHeader();
-	if (std::static_pointer_cast<ProtocolGame>(protocol)) {
+	if (protocol) {
 		size = (size * 8) + 4;
 	}
 

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -159,7 +159,10 @@ void Protocol::XTEA_transform(uint8_t* buffer, size_t messageLength, bool encryp
 
 	while (readPos < messageLength) {
 		std::array<uint8_t, 8> tempBuffer;
-		std::ranges::copy_n(buffer + readPos, 8, tempBuffer.begin());
+		if (std::memcpy(tempBuffer.data(), buffer + readPos, tempBuffer.size()) == nullptr) {
+			g_logger().error("[{}] memcpy failed while preparing XTEA block", __FUNCTION__);
+			return;
+		}
 
 		// Convert bytes to uint32_t considering little-endian order
 		std::array<uint8_t, 4> bytes0;
@@ -209,11 +212,16 @@ void Protocol::XTEA_encrypt(OutputMessage &outputMessage) const {
 
 bool Protocol::XTEA_decrypt(NetworkMessage &msg) const {
 	uint16_t msgLength = msg.getLength() - (checksumMethod == CHECKSUM_METHOD_NONE ? 2 : 6);
+	uint8_t* buffer = msg.getBuffer() + msg.getBufferPosition();
 	if ((msgLength % 8) != 0) {
+		g_logger().error("XTEA_decrypt Failed - invalid block size: {}", msgLength);
+		for (int i = 0; i < msgLength; ++i) {
+			fmt::print("{:02X} ", buffer[i]);
+		}
+		fmt::print("\n");
 		return false;
 	}
 
-	uint8_t* buffer = msg.getBuffer() + msg.getBufferPosition();
 	size_t messageLength = msgLength;
 
 	XTEA_transform(buffer, messageLength, false);
@@ -221,6 +229,7 @@ bool Protocol::XTEA_decrypt(NetworkMessage &msg) const {
 	uint8_t paddingSize = msg.getByte();
 	uint16_t innerLength = messageLength - paddingSize;
 	if (innerLength + paddingSize > msgLength) {
+		g_logger().error("XTEA_decrypt Failed - invalid inner length: {} + {} > {}", innerLength, paddingSize, msgLength);
 		return false;
 	}
 

--- a/src/server/network/protocol/protocol.hpp
+++ b/src/server/network/protocol/protocol.hpp
@@ -67,7 +67,10 @@ protected:
 		encryptionEnabled = true;
 	}
 	void setXTEAKey(const uint32_t* newKey) {
-		std::ranges::copy(newKey, newKey + 4, this->key.begin());
+		if (std::memcpy(key.data(), newKey, sizeof(uint32_t) * key.size()) == nullptr) {
+			g_logger().error("[{}] memcpy failed while setting XTEA key", __FUNCTION__);
+			return;
+		}
 	}
 
 	void setChecksumMethod(ChecksumMethods_t method) {


### PR DESCRIPTION
Replace std::ranges::copy/_copy_n with std::memcpy when copying raw XTEA blocks and key data, and add runtime checks with error logging if memcpy fails.

Improve XTEA_decrypt diagnostics by logging invalid block size, dumping the offending bytes, and logging invalid inner length.
Also simplify the protocol existence check in Connection::parseHeader to avoid an unnecessary static_pointer_cast.

These changes add defensive checks and clearer error messages to help diagnose malformed/encrypted packets.