### PR TITLE
feat: notify player login

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -11227,6 +11227,7 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature> &creature, bool is
 	Creature::onCreatureAppear(creature, isLogin);
 
 	if (isLogin && creature == getPlayer()) {
+		g_logger().info("{} has logged in", getName());
 		onEquipInventory();
 
 		const auto &outfit = Outfits::getInstance().getOutfitByLookType(getPlayer(), defaultOutfit.lookType);


### PR DESCRIPTION
Enables the notification at console:
[2026-13-05 02:17:27.607] [info] Paco has logged in [2026-13-05 02:17:40.975] [info] Paco has logged out

<img width="423" height="35" alt="image" src="https://github.com/user-attachments/assets/0f6b95d4-76a6-4458-8b24-1bbb614680d2" />
