### PR TITLE
fix: addskill talkaction

### DIFF
--- a/data/scripts/talkactions/god/add_skill.lua
+++ b/data/scripts/talkactions/god/add_skill.lua
@@ -4,44 +4,44 @@ local skillMap = {
 	sword = SKILL_SWORD,
 	axe = SKILL_AXE,
 	dist = SKILL_DISTANCE,
+	distance = SKILL_DISTANCE,
 	shield = SKILL_SHIELD,
+	shielding = SKILL_SHIELD,
 	fish = SKILL_FISHING,
+	fishing = SKILL_FISHING,
 }
 
 local function getSkillId(skillName)
-	return skillMap[skillName:match("^%a+")] or SKILL_FIST
+	return skillMap[skillName:lower():match("^%a+")] or SKILL_FIST
 end
 
 local addSkill = TalkAction("/addskill")
 
 function addSkill.onSay(player, words, param)
-	-- Create log
 	logCommand(player, words, param)
 
 	if param == "" then
-		player:sendCancelMessage("Command param required.")
+		player:sendCancelMessage("Usage: /addskill <playername>, <level|magic|skill>, [amount]")
 		return true
 	end
 
 	local split = param:split(",")
 	if #split < 2 then
-		player:sendCancelMessage("Usage: /addskill <playername>, <skill or 'level'/'magic'>, [amount]")
+		player:sendCancelMessage("Usage: /addskill <playername>, <level|magic|skill>, [amount]")
 		return true
 	end
 
 	local targetPlayerName = split[1]:trim()
 	local targetPlayer = Player(targetPlayerName)
-
 	if not targetPlayer then
 		player:sendCancelMessage("Player not found.")
 		return true
 	end
 
-	local skillParam = split[2]:trim()
+	local skillParam = split[2]:trim():lower()
 	local skillIncreaseAmount = tonumber(split[3]) or 1
-	local skillPrefix = skillParam:sub(1, 1)
 
-	if skillPrefix == "l" then
+	if skillParam == "level" then
 		local targetNewLevel = targetPlayer:getLevel() + skillIncreaseAmount
 		local targetNewExp = Game.getExperienceForLevel(targetNewLevel)
 		local experienceToAdd = targetNewExp - targetPlayer:getExperience()
@@ -50,10 +50,18 @@ function addSkill.onSay(player, words, param)
 		targetPlayer:addExperience(experienceToAdd, false)
 		targetPlayer:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("%s has added %d %s to you.", player:getName(), skillIncreaseAmount, levelText))
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("You have successfully added %d %s to player %s.", skillIncreaseAmount, levelText, targetPlayer:getName()))
-	elseif skillPrefix == "m" then
-		for _ = 1, skillIncreaseAmount do
-			local requiredManaSpent = targetPlayer:getVocation():getRequiredManaSpent(targetPlayer:getBaseMagicLevel() + 1)
-			targetPlayer:addManaSpent(requiredManaSpent - targetPlayer:getManaSpent(), true)
+	elseif skillParam == "magic" then
+		local currentML = targetPlayer:getBaseMagicLevel()
+		local toAdd = 0
+
+		for i = currentML + 1, currentML + skillIncreaseAmount do
+			toAdd = toAdd + targetPlayer:getVocation():getRequiredManaSpent(i)
+		end
+
+		toAdd = toAdd - targetPlayer:getManaSpent()
+
+		if toAdd > 0 then
+			targetPlayer:addManaSpent(toAdd)
 		end
 
 		local magicText = (skillIncreaseAmount > 1) and "magic levels" or "magic level"
@@ -62,14 +70,20 @@ function addSkill.onSay(player, words, param)
 	else
 		local skillId = getSkillId(skillParam)
 		for _ = 1, skillIncreaseAmount do
-			local requiredSkillTries = targetPlayer:getVocation():getRequiredSkillTries(skillId, targetPlayer:getSkillLevel(skillId) + 1)
-			targetPlayer:addSkillTries(skillId, requiredSkillTries - targetPlayer:getSkillTries(skillId), true)
+			local currentLevel = targetPlayer:getSkillLevel(skillId)
+			local required = targetPlayer:getVocation():getRequiredSkillTries(skillId, currentLevel + 1)
+			local current = targetPlayer:getSkillTries(skillId)
+			local toAdd = required - current
+			if toAdd > 0 then
+				targetPlayer:addSkillTries(skillId, toAdd, true)
+			end
 		end
 
 		local skillText = (skillIncreaseAmount > 1) and "skill levels" or "skill level"
 		targetPlayer:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("%s has added %d %s %s to you.", player:getName(), skillIncreaseAmount, skillParam, skillText))
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("You have successfully added %d %s %s to player %s.", skillIncreaseAmount, skillParam, skillText, targetPlayer:getName()))
 	end
+
 	return true
 end
 


### PR DESCRIPTION
1.- Handles properly keywords for skills
2.- Corrected logic while handling magic level

I dive into source a little to adapt this, I noticed that magic level won't be updated in your god/gms due the flag: if (hasFlag(PlayerFlags_t::NotGainMana)) {
    return;
}
Because that's how magic level works, but It's fine on regular players.