### PR TITLE
fix: interrogation book

### DIFF
--- a/data-global/scripts/actions/system/quest_reward_common.lua
+++ b/data-global/scripts/actions/system/quest_reward_common.lua
@@ -82,6 +82,21 @@ Knight Brave: Lucky, once again you saved the day!
 Lucky: Woof!
 ]],
 	},
+	[6500] = {
+		text = [[
+I
+
+It is of utmost importance to keep the subject unaware that he is under survey. To begin an inquiry it is necessary to start as casual as possible. The best thing to do is to ask 'how are you?' immediately after the exchange of greeting phrases. If the suspect answers that something troubles him, than immediately ask him about that subject. If not, ask the subject if he had any TROUBLE lately.
+
+II
+
+Next, ask him if he thinks that the AUTHORITIES will handle the subject that troubles him. If he states that the authorities will solve the trouble, ask him if he thinks that they could have AVOIDED the trouble in the first place. If he confirms that the trouble could have been avoided, he is to be observed for heretical tendencies. If the suspect has yet not shown any heretic opinion, ask him why he thinks that the GODS would ALLOW that such things are happening. If he claims that he doesn't know, it is implied that he doubts this godly decision and is to be observed for heretical tendencies. If he comes up with an explanation that suggests that the gods lack the power to prevent that such a thing happens, than he is to be observed for heretical tendencies as well. If he answers that only the gods know the answer or that the gods had some plausible reason, like testing humanity, he may have no heretical tendencies at all.
+
+III
+
+If the suspect claims that he has no trouble at all, ask him if he thinks that the lack of trouble is explained by the FORESIGHT of the AUTHORITIES. If he denies, he is to be observed for heretical tendencies. If he agrees, ask him if he thinks that it is ALSO for the GODS' will that he has no trouble. If he disagrees, he is to be observed for heretical tendencies. If the subject does not show any suspicious behaviour at this point, ask him if he thinks that any TROUBLE will arise in the near FUTURE. If he negates, he obviously will become lax in the line of his duty and he is to be observed for heretical tendencies. If he confirms that trouble might arise, continue as in paragraph II.
+]],
+	},
 }
 
 local achievementTable = {

--- a/data-global/scripts/quests/the_inquisition_quest/movements_reward_room_text.lua
+++ b/data-global/scripts/quests/the_inquisition_quest/movements_reward_room_text.lua
@@ -8,11 +8,11 @@ local rewardRoomText = MoveEvent()
 
 function rewardRoomText.onStepIn(creature, item, position, fromPosition)
 	local player = creature:getPlayer()
-	if not player or player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.RewardRoomText) == 1 then
+	if not player or player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.RewardRoomText) == 2 then
 		return true
 	end
 
-	player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.RewardRoomText, 1)
+	player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.RewardRoomText, 2)
 	player:say("You can choose exactly one of these chests. Choose wisely!", TALKTYPE_MONSTER_SAY)
 	return true
 end

--- a/data-global/startup/tables/chest.lua
+++ b/data-global/startup/tables/chest.lua
@@ -2328,6 +2328,13 @@ ChestUnique = {
 		storage = Storage.Quest.U8_1.WhatAFoolishQuest.BagBookKnife,
 	},
 	-- The Inquisition Quest
+	[6500] = {
+		itemId = 2472,
+		itemPos = { x = 32316, y = 32260, z = 8 },
+		reward = { { 2821, 1 } },
+		weight = 13.00,
+		storage = Storage.Quest.U8_2.TheInquisitionQuest.RewardRoomText,
+	},
 	[6270] = {
 		itemId = 2472,
 		itemPos = { x = 32649, y = 31932, z = 1 },


### PR DESCRIPTION
Alright, just a simple text fix a chest, I took an already existing storage for not fucking up the entire table and ranges. Also lowered the rank of uid set in the map of the chest in order to match the range of the lua.

Isn't much for now but this history here will serve as guide in case you guys want to help me polish the game quests has I've been doing.

Until next time!

PD: Storage.Quest.U8_2.TheInquisitionQuest.RewardRoomText isn't used in questlog so relax bro.