### PR TITLE
feat: retro mana shield

### DIFF
--- a/data/scripts/spells/support/magic_shield.lua
+++ b/data/scripts/spells/support/magic_shield.lua
@@ -5,17 +5,36 @@ combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, var)
-	local condition = Condition(CONDITION_MANASHIELD)
-	condition:setParameter(CONDITION_PARAM_TICKS, 180000)
 	local player = creature:getPlayer()
-	local grade = player:upgradeSpellsWOD("Magic Shield")
-	local shield = 300 + 7.6 * player:getLevel() + 7 * player:getMagicLevel()
-	if grade >= WHEEL_GRADE_REGULAR then
-		shield = shield * 1.25
+	if not player then
+		return combat:execute(creature, var)
 	end
-	if player then
+
+	local condition = Condition(CONDITION_MANASHIELD)
+
+	if not configManager.getBoolean(configKeys.TOGGLE_SERVER_IS_RETRO) then
+		local grade = player:upgradeSpellsWOD("Magic Shield")
+		local shield = 300 + 7.6 * player:getLevel() + 7 * player:getMagicLevel()
+		if grade >= WHEEL_GRADE_REGULAR then
+			shield = shield * 1.25
+		end
+		condition:setParameter(CONDITION_PARAM_TICKS, 180000)
 		condition:setParameter(CONDITION_PARAM_MANASHIELD, math.min(player:getMaxMana(), shield))
+	else
+		local level = player:getLevel()
+		if level < 275 then
+			condition:setParameter(CONDITION_PARAM_TICKS, 200000)
+		else
+			local grade = player:upgradeSpellsWOD("Magic Shield")
+			local shield = 300 + 7.6 * player:getLevel() + 7 * player:getMagicLevel()
+			if grade >= WHEEL_GRADE_REGULAR then
+				shield = shield * 1.25
+			end
+			condition:setParameter(CONDITION_PARAM_TICKS, 180000)
+			condition:setParameter(CONDITION_PARAM_MANASHIELD, math.min(player:getMaxMana(), shield))
+		end
 	end
+
 	creature:addCondition(condition)
 	return combat:execute(creature, var)
 end
@@ -32,5 +51,4 @@ spell:level(14)
 spell:mana(50)
 spell:isSelfTarget(true)
 spell:isAggressive(false)
-
 spell:register()


### PR DESCRIPTION
Only if server is retro, the mana shield will work as it used to be in retro servers. After level 275 (that's when you can access upgrades in the wheel via wheel poins) it behaves normally to avoid breaking the game with invincible mages with mana shield.

If server isn't retro at the config boolean, the spell will behave normally.

Just fine for nostalgia lovers just like me.