### PR TITLE
fix: Update vcpkg baseline and zlib lib name

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -39,5 +39,5 @@
       "platform": "windows"
     }
   ],
-  "builtin-baseline": "d6995a0cf3cafda5e9e52749fad075dd62bfd90c"
+  "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713"
 }

--- a/vcproj/settings.props
+++ b/vcproj/settings.props
@@ -22,7 +22,7 @@
     <CRYSTAL_LIBDEPS>
       $(CRYSTAL_COMMON_LIBDEPS);
       libprotobuf.lib;
-      zlib.lib;
+      z.lib;
       libcurl.lib;
       fmt.lib;
       spdlog.lib;
@@ -30,7 +30,7 @@
     <CRYSTAL_LIBDEPS_D>
       $(CRYSTAL_COMMON_LIBDEPS);
       libprotobufd.lib;
-      zlibd.lib;
+      z.lib;
       libcurl-d.lib;
       fmtd.lib;
       spdlogd.lib;


### PR DESCRIPTION
Bump the vcpkg builtin-baseline to 56bb2411609227288b70117ead2c47585ba07713 in vcpkg.json.
Update vcproj/settings.props to use z.lib for both release and debug (replacing zlib.lib and zlibd.lib) to match the renamed/updated z library artifact and keep project deps in sync with vcpkg outputs.