### PR TITLE
fix: task counter

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -9786,7 +9786,7 @@ const std::unique_ptr<TaskHuntingSlot> &Player::getTaskHuntingWithCreature(uint1
 	}
 
 	if (auto it = std::ranges::find_if(taskHunting, [raceId](const std::unique_ptr<TaskHuntingSlot> &itTask) {
-			return itTask->selectedRaceId == raceId;
+			return itTask->selectedRaceId == raceId && itTask->state == PreyTaskDataState_Active;
 		});
 	    it != taskHunting.end()) {
 		return *it;


### PR DESCRIPTION
This fix will count the kills only if task is actually started in the prey system. I got just had a weird bug with crypt warrior, somehow the task started by itself, but this will fix it.