### PR TITLE
feat: rotate in android

### DIFF
--- a/data/scripts/talkactions/player/rotate.lua
+++ b/data/scripts/talkactions/player/rotate.lua
@@ -1,0 +1,12 @@
+local function onSayRotate(player, words, param)
+    local currentDir = player:getDirection()
+    local nextDir = (currentDir + 1) % 4
+    player:setDirection(nextDir)
+    local dirNames = { [0] = "north", [1] = "east", [2] = "south", [3] = "west" }
+    return true
+end
+
+local talkAction = TalkAction("!r", "!rotate")
+talkAction:onSay(onSayRotate)
+talkAction:groupType("normal")
+talkAction:register()

--- a/data/scripts/talkactions/player/rotate.lua
+++ b/data/scripts/talkactions/player/rotate.lua
@@ -1,9 +1,9 @@
 local function onSayRotate(player, words, param)
-    local currentDir = player:getDirection()
-    local nextDir = (currentDir + 1) % 4
-    player:setDirection(nextDir)
-    local dirNames = { [0] = "north", [1] = "east", [2] = "south", [3] = "west" }
-    return true
+	local currentDir = player:getDirection()
+	local nextDir = (currentDir + 1) % 4
+	player:setDirection(nextDir)
+	local dirNames = { [0] = "north", [1] = "east", [2] = "south", [3] = "west" }
+	return true
 end
 
 local talkAction = TalkAction("!r", "!rotate")

--- a/data/scripts/talkactions/player/rotate.lua
+++ b/data/scripts/talkactions/player/rotate.lua
@@ -6,7 +6,7 @@ local function onSayRotate(player, words, param)
 	return true
 end
 
-local talkAction = TalkAction("!r", "!rotate")
+local talkAction = TalkAction("!r")
 talkAction:onSay(onSayRotate)
 talkAction:groupType("normal")
 talkAction:register()


### PR DESCRIPTION
Playing in phone and got stuck while using levitate? - No more, just use !r or !rotate commands to turn your character direction and cast the magic spell.