### PR TITLE
fix: Persist hunting task shop wheel points

### DIFF
--- a/data-global/lib/others/newhaven.lua
+++ b/data-global/lib/others/newhaven.lua
@@ -8,9 +8,9 @@ Newhaven.starterItems = {
 			{ 3559, 1, CONST_SLOT_LEGS }, -- leather legs
 			{ 3552, 1, CONST_SLOT_FEET }, -- leather boots
 			{ 34017, 1, CONST_SLOT_AMMO }, -- lit torch
-			
+
 			{ 21400, 1, CONST_SLOT_RIGHT }, -- spellbook of the novice
-			{ 21348, 1, CONST_SLOT_LEFT }, -- the scorcher	
+			{ 21348, 1, CONST_SLOT_LEFT }, -- the scorcher
 		},
 		container = {
 			{ 268, 10 }, -- mana potion
@@ -27,7 +27,7 @@ Newhaven.starterItems = {
 			{ 3559, 1, CONST_SLOT_LEGS }, -- leather legs
 			{ 3552, 1, CONST_SLOT_FEET }, -- leather boots
 			{ 34017, 1, CONST_SLOT_AMMO }, -- lit torch
-			
+
 			{ 21400, 1, CONST_SLOT_RIGHT }, -- spellbook of the novice
 			{ 21350, 1, CONST_SLOT_LEFT }, -- the chiller
 		},
@@ -46,7 +46,7 @@ Newhaven.starterItems = {
 			{ 3559, 1, CONST_SLOT_LEGS }, -- leather legs
 			{ 3552, 1, CONST_SLOT_FEET }, -- leather boots
 			{ 34017, 1, CONST_SLOT_AMMO }, -- lit torch
-			
+
 			{ 3350, 1, CONST_SLOT_LEFT }, -- bow
 			{ 35562, 1, CONST_SLOT_RIGHT }, -- quiver
 		},
@@ -64,7 +64,7 @@ Newhaven.starterItems = {
 			{ 3559, 1, CONST_SLOT_LEGS }, -- leather legs
 			{ 3552, 1, CONST_SLOT_FEET }, -- leather boots
 			{ 34017, 1, CONST_SLOT_AMMO }, -- lit torch
-			
+
 			{ 3272, 1, CONST_SLOT_LEFT }, -- rapier
 			{ 3412, 1, CONST_SLOT_RIGHT }, -- wooden shield
 		},
@@ -82,7 +82,7 @@ Newhaven.starterItems = {
 			{ 3559, 1, CONST_SLOT_LEGS }, -- leather legs
 			{ 3552, 1, CONST_SLOT_FEET }, -- leather boots
 			{ 34017, 1, CONST_SLOT_AMMO }, -- lit torch
-			
+
 			{ 50166, 1, CONST_SLOT_LEFT }, -- light jo staff
 		},
 		container = {
@@ -143,4 +143,3 @@ function Newhaven.giveStarterItems(player)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You received your starter equipment.")
 	return true
 end
-

--- a/data-global/npc/avriel.lua
+++ b/data-global/npc/avriel.lua
@@ -125,7 +125,6 @@ npcConfig.shop = {
 	{ itemName = "stone skin amulet", clientId = 3081, sell = 500 },
 	{ itemName = "wand of vortex", clientId = 3074, sell = 100 },
 	{ itemName = "white mushroom", clientId = 3723, sell = 2 },
-
 }
 
 -- On buy npc shop message

--- a/data-global/npc/enpa_deia_pema.lua
+++ b/data-global/npc/enpa_deia_pema.lua
@@ -80,6 +80,7 @@ local function creatureSayCallback(npc, creature, type, message)
 				npcHandler:say("You have honored our legacy! On behalf of all Merudri, I thank you, venerable traveler.", npc, creature)
 				kv:set("questline", 4)
 				kv:set("questlog", 4)
+				kv:set("boolPointsWheel", true)
 				player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questline, 4)
 				player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questlog, 4)
 				local title = Game.getTitleByName("Pensive Wanderer")
@@ -88,6 +89,9 @@ local function creatureSayCallback(npc, creature, type, message)
 				end
 				player:addAchievement("Hope of the Merudri")
 			else
+				if not kv:get("boolPointsWheel") then
+					kv:set("boolPointsWheel", true)
+				end
 				npcHandler:say("You have already completed the pilgrimage and honored our legacy.", npc, creature)
 			end
 		else

--- a/data-global/scripts/quests/the_way_of_the_monk/actions_mainland_shrines.lua
+++ b/data-global/scripts/quests/the_way_of_the_monk/actions_mainland_shrines.lua
@@ -65,7 +65,7 @@ function shrineAction.onUse(player, item, fromPosition, target, toPosition, isHo
 	local newCount = math.max(1, (kv:get(shrineConfig.counterKey) or 0) + 1)
 	kv:set(shrineConfig.counterKey, newCount)
 
-	if newCount == 14 then
+	if newCount == 14 or shrine.order == 10 then
 		kv:set("boolPointsWheel", true)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your pilgrimage is complete. Report to Enpa-Deia Pema for a reward.")
 		toPosition:sendMagicEffect(CONST_ME_HOLYAREA)

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -1933,7 +1933,6 @@ uint16_t PlayerWheel::getExtraPoints() const {
 		totalBonus += 10;
 	}
 
-	// totalBonus += m_extraPointsFromHuntingTaskShop;
 	totalBonus += getExtraPointsFromHuntingTaskShop();
 	return totalBonus;
 }

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -1933,6 +1933,8 @@ uint16_t PlayerWheel::getExtraPoints() const {
 		totalBonus += 10;
 	}
 
+	// totalBonus += m_extraPointsFromHuntingTaskShop;
+	totalBonus += getExtraPointsFromHuntingTaskShop();
 	return totalBonus;
 }
 
@@ -1959,7 +1961,6 @@ uint16_t PlayerWheel::getWheelPoints(bool includeExtraPoints /* = true*/) const 
 
 	if (includeExtraPoints) {
 		totalPoints += getExtraPoints();
-		totalPoints += getExtraPointsFromHuntingTaskShop();
 	}
 
 	return totalPoints;
@@ -4114,13 +4115,18 @@ PlayerWheelGem PlayerWheelGem::deserialize(const std::string &uuid, const ValueW
 }
 
 bool PlayerWheel::hasMonkQuest() const {
-	const auto &kvScoped = m_player.kv()->scoped("the_way_of_the_monk_quest");
+	const auto &kvScoped = m_player.kv()->scoped("quests")->scoped("the_way_of_the_monk_quest");
 	if (!kvScoped) {
 		return false;
 	}
 
 	const auto boolPointsWheel = kvScoped->get("boolPointsWheel");
-	return boolPointsWheel ? boolPointsWheel->get<bool>() : false;
+	if (boolPointsWheel && boolPointsWheel->get<bool>()) {
+		return true;
+	}
+
+	const auto questline = kvScoped->get("questline");
+	return questline && questline->getNumber() >= 4;
 }
 
 int32_t PlayerWheel::checkRevelationPerkAscetic() const {

--- a/src/io/ioweeklytasks.cpp
+++ b/src/io/ioweeklytasks.cpp
@@ -674,6 +674,7 @@ void IOWeeklyTasks::buyShopOffer(const std::shared_ptr<Player> &player, uint8_t 
 		}
 		case HUNTING_SHOP_OFFER_BONUS_PROMOTION: {
 			player->wheel()->addExtraPointsFromHuntingTaskShop(1);
+			player->wheel()->saveKVHuntingTaskShopExtraPoints();
 			player->sendTextMessage(MESSAGE_STATUS, "You have purchased an extra Wheel of Destiny promotion point.");
 			break;
 		}


### PR DESCRIPTION
- Ensure extra Wheel of Destiny points bought from the Hunting Task Shop are persisted and counted. 
- Key changes: set kv flag boolPointsWheel in NPC and shrine scripts (shrine also sets it when shrine.order == 10), include getExtraPointsFromHuntingTaskShop() in getExtraPoints(), avoid double counting in getWheelPoints(), call saveKVHuntingTaskShopExtraPoints() when purchasing the promotion, and adjust KV scoping plus hasMonkQuest() to check boolPointsWheel or questline >= 4. 
- These fixes make purchased promotion points survive restarts and be reflected in wheel totals and quest completion logic.

Related to issue #756