### PR TITLE
fix: Client crash on Disconnect Message

### DIFF
--- a/src/enums/disconnect_client.hpp
+++ b/src/enums/disconnect_client.hpp
@@ -1,0 +1,28 @@
+////////////////////////////////////////////////////////////////////////
+// Crystal Server - an opensource roleplaying game
+////////////////////////////////////////////////////////////////////////
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <cstdint>
+#endif
+
+enum class DisconnectClient_t : uint8_t {
+	Default = 0,
+	Notice = 1,
+	Outdated = 2,
+};

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -964,7 +964,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 			message = fmt::format("You are already logged in using protocol '{}'. Please log out from the other session to connect here.", foundPlayer->getProtocolVersion());
 		}
 
-		foundPlayer->client->disconnectClient(message);
+		foundPlayer->client->disconnectClient(message, DisconnectClient_t::Notice);
 	}
 
 	auto timeStamp = msg.get<uint32_t>();
@@ -987,7 +987,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 			ss << " or 11.00";
 		}
 		ss << " allowed!";
-		disconnectClient(ss.str());
+		disconnectClient(ss.str(), DisconnectClient_t::Outdated);
 		return;
 	}
 
@@ -1023,13 +1023,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 			ss << "Your " << (oldProtocol ? "username" : "email") << " or password is not correct.";
 		}
 
-		auto output = OutputMessagePool::getOutputMessage();
-		output->addByte(0x14);
-		output->addString(ss.str());
-		send(output);
-		g_dispatcher().scheduleEvent(
-			1000, [self = getThis()] { self->disconnect(); }, "ProtocolGame::disconnect"
-		);
+		disconnectClient(ss.str(), DisconnectClient_t::Default);
 		return;
 	}
 
@@ -1064,10 +1058,11 @@ void ProtocolGame::sendLoginChallenge() {
 	send(output);
 }
 
-void ProtocolGame::disconnectClient(const std::string &message) const {
+void ProtocolGame::disconnectClient(const std::string &message, DisconnectClient_t reason) const {
 	auto output = OutputMessagePool::getOutputMessage();
 	output->addByte(0x14);
 	output->addString(message);
+	output->addByte(static_cast<uint8_t>(reason));
 	send(output);
 	disconnect();
 }

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -17,9 +17,11 @@
 
 #pragma once
 
-#include "server/network/protocol/protocol.hpp"
 #include <unordered_map>
+
+#include "server/network/protocol/protocol.hpp"
 #include "creatures/creatures_definitions.hpp"
+#include "enums/disconnect_client.hpp"
 #include "game/movement/position.hpp"
 #include "utils/utils_definitions.hpp"
 
@@ -131,7 +133,7 @@ private:
 		return std::static_pointer_cast<ProtocolGame>(shared_from_this());
 	}
 	void connect(const std::string &playerName, OperatingSystem_t operatingSystem);
-	void disconnectClient(const std::string &message) const;
+	void disconnectClient(const std::string &message, DisconnectClient_t reason = DisconnectClient_t::Default) const;
 	void writeToOutputBuffer(NetworkMessage &msg);
 
 	void release() override;


### PR DESCRIPTION
This PR fixes all client crash related to Disconnect Client function, including the issue #765