### PR TITLE
feat: Add JSON event scheduler and fix exercise training

### DIFF
--- a/data/json/eventscheduler/events.json
+++ b/data/json/eventscheduler/events.json
@@ -1,0 +1,184 @@
+{
+	"events": [
+		{
+			"name": "Forge Time",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"forgechance": 120
+			},
+			"description": "Increases the success rate of forges by 20%.",
+			"colors": {
+				"colordark": "#2b3e50",
+				"colorlight": "#3d5a73"
+			},
+			"details": {
+				"displaypriority": 5,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Double Bestiary",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"doublebestiary": true
+			},
+			"description": "Doubles the bestiary counter when defeating monsters.",
+			"colors": {
+				"colordark": "#3a4f2a",
+				"colorlight": "#4f713a"
+			},
+			"details": {
+				"displaypriority": 5,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Fast Exercise",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"fastexercise": true
+			},
+			"description": "Exercise weapons are faster, doubling their speed.",
+			"colors": {
+				"colordark": "#5a3a2a",
+				"colorlight": "#7b4f3a"
+			},
+			"details": {
+				"displaypriority": 5,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "50% Loot Bonus",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"lootrate": 150
+			},
+			"description": "Increases loot by 50%.",
+			"colors": {
+				"colordark": "#2b1e10",
+				"colorlight": "#4a2e18"
+			},
+			"details": {
+				"displaypriority": 6,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "50% Exp Bonus",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"exprate": 150
+			},
+			"description": "Increases experience by 50%.",
+			"colors": {
+				"colordark": "#234d00",
+				"colorlight": "#3a7500"
+			},
+			"details": {
+				"displaypriority": 6,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Boss Cooldown Reduction",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"bosscooldown": 150
+			},
+			"description": "Reduces boss cooldown time by 50%.",
+			"colors": {
+				"colordark": "#2d3c5a",
+				"colorlight": "#4a5f7d"
+			},
+			"details": {
+				"displaypriority": 6,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Double Exp",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"exprate": 200
+			},
+			"description": "Double experience when hunting monsters.",
+			"colors": {
+				"colordark": "#002d00",
+				"colorlight": "#004400"
+			},
+			"details": {
+				"displaypriority": 6,
+				"isseasonal": 1,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Double Loot",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"lootrate": 200
+			},
+			"description": "Doubles the amount of loot obtained from monsters.",
+			"colors": {
+				"colordark": "#2a1d00",
+				"colorlight": "#4c3300"
+			},
+			"details": {
+				"displaypriority": 6,
+				"isseasonal": 1,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Double Bosstiary",
+			"startdate": "11/12/2024",
+			"enddate": "11/17/2024",
+			"ingame": {
+				"doublebosstiary": true
+			},
+			"description": "Doubles the bestiary counter for bosses.",
+			"colors": {
+				"colordark": "#3a005a",
+				"colorlight": "#4e0075"
+			},
+			"details": {
+				"displaypriority": 5,
+				"isseasonal": 0,
+				"specialevent": 1
+			}
+		},
+		{
+			"name": "Fast Respawn",
+			"startdate": "11/01/2024",
+			"enddate": "11/15/2024",
+			"ingame": {
+				"spawnrate": 200
+			},
+			"description": "Monsters respawn twice as fast.",
+			"colors": {
+				"colordark": "#4d2f00",
+				"colorlight": "#6e3e00"
+			},
+			"details": {
+				"displaypriority": 6,
+				"isseasonal": 1,
+				"specialevent": 1
+			}
+		}
+	]
+}

--- a/data/scripts/actions/items/exercise_training_weapons.lua
+++ b/data/scripts/actions/items/exercise_training_weapons.lua
@@ -42,7 +42,7 @@ local exerciseWeaponsTable = {
 
 local dummies = Game.getDummies()
 
-local function leaveExerciseTraining(playerId)
+local function leaveExerciseTraining(playerId, targetItem)
 	if _G.OnExerciseTraining[playerId] then
 		stopEvent(_G.OnExerciseTraining[playerId].event)
 		_G.OnExerciseTraining[playerId] = nil
@@ -51,6 +51,9 @@ local function leaveExerciseTraining(playerId)
 	local player = Player(playerId)
 	if player then
 		player:setTraining(false)
+		if targetItem then
+			targetItem:actor(false)
+		end
 	end
 	return
 end
@@ -61,15 +64,16 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 		return leaveExerciseTraining(playerId)
 	end
 
-	if player:isTraining() == 0 then
-		player:sendTextMessage(MESSAGE_FAILURE, "You have stopped training.")
-		return leaveExerciseTraining(playerId)
+	local targetItem = Tile(tilePosition):getItemById(dummyId)
+	if not targetItem then
+		player:sendTextMessage(MESSAGE_FAILURE, "Someone has moved the dummy, the training has stopped.")
+		leaveExerciseTraining(playerId, targetItem)
+		return false
 	end
 
-	if not Tile(tilePosition):getItemById(dummyId) then
-		player:sendTextMessage(MESSAGE_FAILURE, "Someone has moved the dummy, the training has stopped.")
-		leaveExerciseTraining(playerId)
-		return false
+	if player:isTraining() == 0 then
+		player:sendTextMessage(MESSAGE_FAILURE, "You have stopped training.")
+		return leaveExerciseTraining(playerId, targetItem)
 	end
 
 	local playerPosition = player:getPosition()
@@ -81,14 +85,14 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 
 	if player:getItemCount(weaponId) <= 0 then
 		player:sendTextMessage(MESSAGE_FAILURE, "You need the training weapon in the backpack, the training has stopped.")
-		leaveExerciseTraining(playerId)
+		leaveExerciseTraining(playerId, targetItem)
 		return false
 	end
 
 	local weapon = player:getItemById(weaponId, true)
 	if not weapon:isItem() or not weapon:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
 		player:sendTextMessage(MESSAGE_FAILURE, "The selected item is not a training weapon, the training has stopped.")
-		leaveExerciseTraining(playerId)
+		leaveExerciseTraining(playerId, targetItem)
 		return false
 	end
 
@@ -96,7 +100,7 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 	if not weaponCharges or weaponCharges <= 0 then
 		weapon:remove(1) -- ??
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon has disappeared.")
-		leaveExerciseTraining(playerId)
+		leaveExerciseTraining(playerId, targetItem)
 		return false
 	end
 
@@ -107,7 +111,7 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 	local rate = dummies[dummyId] / 100
 	local isMagic = exerciseWeaponsTable[weaponId].skill == SKILL_MAGLEVEL
 	if isMagic then
-		player:addManaSpent(500 * rate)
+		player:addManaSpent(600 * rate)
 	else
 		player:addSkillTries(exerciseWeaponsTable[weaponId].skill, 7 * rate)
 	end
@@ -122,12 +126,19 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 	if weapon:getAttribute(ITEM_ATTRIBUTE_CHARGES) <= 0 then
 		weapon:remove(1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon has disappeared.")
-		leaveExerciseTraining(playerId)
+		leaveExerciseTraining(playerId, targetItem)
 		return false
 	end
 
+	local eventSpeedMultiplier = 1
+	local scopedFastExercise = KV.scoped("eventscheduler"):get("fast-exercise")
+	if scopedFastExercise then
+		eventSpeedMultiplier = 0.5
+		logger.debug("Fast exercise is enabled.")
+	end
+
 	local vocation = player:getVocation()
-	_G.OnExerciseTraining[playerId].event = addEvent(exerciseTrainingEvent, vocation:getBaseAttackSpeed() / configManager.getFloat(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
+	_G.OnExerciseTraining[playerId].event = addEvent(exerciseTrainingEvent, (vocation:getBaseAttackSpeed() / configManager.getFloat(configKeys.RATE_EXERCISE_TRAINING_SPEED)) * eventSpeedMultiplier, playerId, tilePosition, weaponId, dummyId)
 	return true
 end
 
@@ -145,7 +156,8 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 	local playerId = player:getId()
 	local targetId = target:getId()
 
-	if target:isItem() and isDummy(targetId) then
+	local targetItem = Item(target.uid)
+	if targetItem and isDummy(targetId) then
 		if _G.OnExerciseTraining[playerId] then
 			player:sendTextMessage(MESSAGE_FAILURE, "You are already training!")
 			return true
@@ -194,6 +206,7 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 		if not _G.OnExerciseTraining[playerId].event then
 			_G.OnExerciseTraining[playerId].event = addEvent(exerciseTrainingEvent, 0, playerId, targetPos, item.itemid, targetId)
 			_G.OnExerciseTraining[playerId].dummyPos = targetPos
+			targetItem:actor(true)
 			player:setTraining(true)
 			player:setExhaustion("training-exhaustion", exhaustionTime)
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have started training on an exercise dummy.")

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6472,6 +6472,14 @@ void Player::addBestiaryKill(const std::shared_ptr<MonsterType> &mType) {
 		return;
 	}
 	uint32_t kills = g_configManager().getNumber(BESTIARY_KILL_MULTIPLIER);
+
+	auto scopedDoubleBestiary = g_kv().scoped("eventscheduler")->get("double-bestiary");
+	bool doubleBestiaryEnabled = scopedDoubleBestiary && scopedDoubleBestiary->get<bool>();
+	if (doubleBestiaryEnabled) {
+		kills *= 2;
+		g_logger().debug("[{}] double bestiary is enabled.", __FUNCTION__);
+	}
+
 	if (isConcoctionActive(Concoction_t::BestiaryBetterment)) {
 		kills *= 2;
 	}
@@ -6491,6 +6499,14 @@ void Player::addBosstiaryKill(const std::shared_ptr<MonsterType> &mType) {
 		return;
 	}
 	uint32_t kills = g_configManager().getNumber(BOSSTIARY_KILL_MULTIPLIER);
+
+	auto scopedDoubleBosstiary = g_kv().scoped("eventscheduler")->get("double-bosstiary");
+	bool doubleBosstiaryEnabled = scopedDoubleBosstiary && scopedDoubleBosstiary->get<bool>();
+	if (doubleBosstiaryEnabled) {
+		kills *= 2;
+		g_logger().debug("[{}] double bosstiary is enabled.", __FUNCTION__);
+	}
+
 	if (g_ioBosstiary().getBoostedBossId() == mType->info.raceid) {
 		kills *= g_configManager().getNumber(BOOSTED_BOSS_KILL_BONUS);
 	}

--- a/src/crystalserver.cpp
+++ b/src/crystalserver.cpp
@@ -352,6 +352,7 @@ void CrystalServer::loadModules() {
 	// Load XML folder dependencies (order matters)
 	modulesLoadHelper(g_vocations().loadFromXml(), "XML/vocations.xml");
 	modulesLoadHelper(g_eventsScheduler().loadScheduleEventFromXml(), "XML/events.xml");
+	modulesLoadHelper(g_eventsScheduler().loadScheduleEventFromJson(), "json/eventscheduler/events.json");
 	modulesLoadHelper(Outfits::getInstance().loadFromXml(), "XML/outfits.xml");
 	modulesLoadHelper(Familiars::getInstance().loadFromXml(), "XML/familiars.xml");
 	modulesLoadHelper(g_imbuements().loadFromXml(), "XML/imbuements.xml");

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -188,6 +188,7 @@ namespace InternalGame {
 			}
 
 			auto isGuest = house->getHouseAccessLevel(player) == HOUSE_GUEST;
+			auto isOwner = house->getHouseAccessLevel(player) == HOUSE_OWNER;
 			auto itemParentContainer = item->getParent() ? item->getParent()->getContainer() : nullptr;
 			auto isItemParentContainerBrowseField = itemParentContainer && itemParentContainer->getID() == ITEM_BROWSEFIELD;
 			if (isGuest && isItemParentContainerBrowseField) {
@@ -200,7 +201,7 @@ namespace InternalGame {
 				return false;
 			}
 
-			if (isGuest && item->isDummy()) {
+			if (!isOwner && item->isDummy() && (isGuest || item->hasActor())) {
 				return false;
 			}
 		}
@@ -10641,6 +10642,11 @@ void Game::playerForgeFuseItems(uint32_t playerId, ForgeAction_t actionType, uin
 
 	uint8_t coreCount = (usedCore ? 1 : 0) + (reduceTierLoss ? 1 : 0);
 	auto baseSuccess = static_cast<uint8_t>(g_configManager().getNumber(FORGE_BASE_SUCCESS_RATE));
+	if (const auto scopedForgeChance = g_kv().scoped("eventscheduler")->get("forge-chance")) {
+		auto forgeChance = static_cast<int>(scopedForgeChance->getNumber());
+		int adjustedSuccess = baseSuccess + forgeChance - 100;
+		baseSuccess = static_cast<uint8_t>(std::clamp(adjustedSuccess, 0, 100));
+	}
 	auto coreSuccess = usedCore ? g_configManager().getNumber(FORGE_BONUS_SUCCESS_RATE) : 0;
 	auto finalRate = baseSuccess + coreSuccess;
 	auto roll = static_cast<uint8_t>(uniform_random(1, 100)) <= finalRate;

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -18,52 +18,350 @@
 #include "game/scheduling/events_scheduler.hpp"
 
 #include "config/configmanager.hpp"
+#include "kv/kv.hpp"
 #include "lua/scripts/scripts.hpp"
+
+#include <fstream>
+#include <map>
+#include <nlohmann/json.hpp>
+
+namespace {
+	bool parseDateTime(const std::string &dateStr, const std::string &timeStr, std::time_t &result) {
+		int month = 0;
+		int day = 0;
+		int year = 0;
+		if (sscanf(dateStr.c_str(), "%d/%d/%d", &month, &day, &year) != 3) {
+			return false;
+		}
+		int hour = 0;
+		int minute = 0;
+		int second = 0;
+		if (!timeStr.empty()) {
+			const int parsed = sscanf(timeStr.c_str(), "%d:%d:%d", &hour, &minute, &second);
+			if (parsed < 2) {
+				return false;
+			}
+			if (parsed == 2) {
+				second = 0;
+			}
+		}
+		if (hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59) {
+			return false;
+		}
+		std::tm tmDate {};
+		tmDate.tm_year = year - 1900;
+		tmDate.tm_mon = month - 1;
+		tmDate.tm_mday = day;
+		tmDate.tm_hour = hour;
+		tmDate.tm_min = minute;
+		tmDate.tm_sec = second;
+		tmDate.tm_isdst = -1;
+		const std::time_t timestamp = std::mktime(&tmDate);
+		if (timestamp == static_cast<std::time_t>(-1)) {
+			return false;
+		}
+		result = timestamp;
+		return true;
+	}
+}
+
+void EventsScheduler::reset() {
+	expSchedule = 100;
+	lootSchedule = 100;
+	bossLootSchedule = 100;
+	skillSchedule = 100;
+	spawnMonsterSchedule = 100;
+	fiendishSchedule = 100;
+	influencedSchedule = 100;
+	eventScheduler.clear();
+
+	g_kv().scoped("eventscheduler")->remove("forge-chance");
+	g_kv().scoped("eventscheduler")->remove("double-bestiary");
+	g_kv().scoped("eventscheduler")->remove("double-bosstiary");
+	g_kv().scoped("eventscheduler")->remove("fast-exercise");
+	g_kv().scoped("eventscheduler")->remove("boss-cooldown");
+}
+
+std::vector<std::string> EventsScheduler::getActiveEvents() const {
+	std::vector<std::string> activeEvents;
+	const auto now = getTimeNow();
+	for (const auto &event : eventScheduler) {
+		if (now >= event.startTime && now <= event.endTime) {
+			activeEvents.emplace_back(event.name);
+		}
+	}
+	return activeEvents;
+}
+
+bool EventsScheduler::loadScheduleEventFromJson() {
+	using json = nlohmann::json;
+	const auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
+	const auto folder = coreFolder + "/json/eventscheduler/events.json";
+	std::ifstream file(folder);
+	if (!file.is_open()) {
+		g_logger().warn("{} - File '{}' not found, skipping JSON event scheduler", __FUNCTION__, folder);
+		return true;
+	}
+
+	json eventsJson;
+	try {
+		file >> eventsJson;
+	} catch (const json::parse_error &e) {
+		g_logger().error("{} - JSON parsing error in file '{}': {}", __FUNCTION__, folder, e.what());
+		consoleHandlerExit();
+		return false;
+	}
+
+	const auto now = getTimeNow();
+
+	phmap::flat_hash_set<std::string> loadedScripts;
+	std::map<std::string, EventRates> eventsOnSameDay;
+
+	for (const auto &event : eventsJson["events"]) {
+		std::string eventScript = event.contains("script") && !event["script"].is_null() ? event["script"].get<std::string>() : "";
+		std::string eventName = event.value("name", "");
+
+		if (!event.contains("startdate") || !event.contains("enddate")) {
+			g_logger().warn("{} - Missing 'startdate' or 'enddate' for event '{}'", __FUNCTION__, eventName);
+			continue;
+		}
+
+		const std::string defaultHour = event.contains("hour") && !event["hour"].is_null() ? event["hour"].get<std::string>() : std::string {};
+		const std::string startHour = event.contains("starthour") && !event["starthour"].is_null() ? event["starthour"].get<std::string>() : (!defaultHour.empty() ? defaultHour : "00:00");
+		const std::string endHour = event.contains("endhour") && !event["endhour"].is_null() ? event["endhour"].get<std::string>() : (!defaultHour.empty() ? defaultHour : "23:59:59");
+		std::time_t startTime {};
+		std::time_t endTime {};
+		if (!parseDateTime(event["startdate"].get<std::string>(), startHour, startTime) || !parseDateTime(event["enddate"].get<std::string>(), endHour, endTime)) {
+			g_logger().warn("{} - Invalid date or hour format for event '{}'", __FUNCTION__, eventName);
+			continue;
+		}
+		if (endTime < startTime) {
+			g_logger().warn("{} - Event '{}' end time is before start time", __FUNCTION__, eventName);
+			continue;
+		}
+
+		if (now < startTime || now > endTime) {
+			continue;
+		}
+
+		if (!eventScript.empty()) {
+			if (loadedScripts.contains(eventScript)) {
+				g_logger().warn("{} - Script declaration '{}' is duplicated in '{}'", __FUNCTION__, eventScript, folder);
+				continue;
+			}
+
+			loadedScripts.insert(eventScript);
+			const std::filesystem::path filePath = std::filesystem::current_path() / coreFolder / "json" / "eventscheduler" / "scripts" / eventScript;
+
+			if (!std::filesystem::exists(filePath) || !std::filesystem::is_regular_file(filePath)) {
+				g_logger().warn("{} - Cannot find script file '{}'", __FUNCTION__, filePath.string());
+				return false;
+			}
+
+			if (!g_scripts().loadEventSchedulerScripts(filePath)) {
+				g_logger().warn("{} - Cannot load the file '{}' on '{}/json/eventscheduler/scripts/'", __FUNCTION__, eventScript, coreFolder);
+				return false;
+			}
+		}
+
+		EventRates currentEventRates;
+		if (event.contains("ingame") && event["ingame"].is_object()) {
+			const auto &ingame = event["ingame"];
+			currentEventRates.exprate = static_cast<uint16_t>(ingame.value("exprate", 100));
+			currentEventRates.lootrate = static_cast<uint32_t>(ingame.value("lootrate", 100));
+			currentEventRates.bosslootrate = static_cast<uint32_t>(ingame.value("bosslootrate", 100));
+			currentEventRates.spawnrate = static_cast<uint32_t>(ingame.value("spawnrate", 100));
+			currentEventRates.skillrate = static_cast<uint16_t>(ingame.value("skillrate", 100));
+			currentEventRates.fiendishrate = static_cast<uint16_t>(ingame.value("fiendishrate", 100));
+			currentEventRates.influencedrate = static_cast<uint16_t>(ingame.value("influencedrate", 100));
+			if (ingame.contains("forgechance")) {
+				currentEventRates.forgeChance = static_cast<uint8_t>(ingame.value("forgechance", 100));
+			} else if (ingame.contains("forge-chance")) {
+				currentEventRates.forgeChance = static_cast<uint8_t>(ingame.value("forge-chance", 100));
+			}
+			currentEventRates.bosscooldown = static_cast<uint8_t>(ingame.value("bosscooldown", 100));
+			currentEventRates.doubleBestiary = ingame.value("doublebestiary", false);
+			currentEventRates.doubleBossTiary = ingame.value("doublebosstiary", false);
+			if (ingame.contains("fastexercise")) {
+				currentEventRates.fastExercise = ingame.value("fastexercise", false);
+			} else if (ingame.contains("doubleexercise")) {
+				currentEventRates.fastExercise = ingame.value("doubleexercise", false);
+			}
+		}
+
+		bool applyExp = currentEventRates.exprate != 100;
+		bool applyLoot = currentEventRates.lootrate != 100;
+		bool applyBossLoot = currentEventRates.bosslootrate != 100;
+		bool applySpawn = currentEventRates.spawnrate != 100;
+		bool applySkill = currentEventRates.skillrate != 100;
+		bool applyFiendish = currentEventRates.fiendishrate != 100;
+		bool applyInfluenced = currentEventRates.influencedrate != 100;
+		bool applyForge = currentEventRates.forgeChance != 100;
+		bool applyDoubleBestiary = currentEventRates.doubleBestiary;
+		bool applyDoubleBosstiary = currentEventRates.doubleBossTiary;
+		bool applyFastExercise = currentEventRates.fastExercise;
+		bool applyBossCooldown = currentEventRates.bosscooldown != 100;
+		std::unordered_map<std::string, std::vector<std::string>> duplicatedRates;
+		for (const auto &[existingEventName, rates] : eventsOnSameDay) {
+			if (applyExp && rates.exprate != 100 && rates.exprate == currentEventRates.exprate) {
+				duplicatedRates[existingEventName].emplace_back("exprate");
+				applyExp = false;
+			}
+			if (applyLoot && rates.lootrate != 100 && rates.lootrate == currentEventRates.lootrate) {
+				duplicatedRates[existingEventName].emplace_back("lootrate");
+				applyLoot = false;
+			}
+			if (applyBossLoot && rates.bosslootrate != 100 && rates.bosslootrate == currentEventRates.bosslootrate) {
+				duplicatedRates[existingEventName].emplace_back("bosslootrate");
+				applyBossLoot = false;
+			}
+			if (applySpawn && rates.spawnrate != 100 && rates.spawnrate == currentEventRates.spawnrate) {
+				duplicatedRates[existingEventName].emplace_back("spawnrate");
+				applySpawn = false;
+			}
+			if (applySkill && rates.skillrate != 100 && rates.skillrate == currentEventRates.skillrate) {
+				duplicatedRates[existingEventName].emplace_back("skillrate");
+				applySkill = false;
+			}
+			if (applyFiendish && rates.fiendishrate != 100 && rates.fiendishrate == currentEventRates.fiendishrate) {
+				duplicatedRates[existingEventName].emplace_back("fiendishrate");
+				applyFiendish = false;
+			}
+			if (applyInfluenced && rates.influencedrate != 100 && rates.influencedrate == currentEventRates.influencedrate) {
+				duplicatedRates[existingEventName].emplace_back("influencedrate");
+				applyInfluenced = false;
+			}
+			if (applyForge && rates.forgeChance != 100 && rates.forgeChance == currentEventRates.forgeChance) {
+				duplicatedRates[existingEventName].emplace_back("forge-chance");
+				applyForge = false;
+			}
+			if (applyDoubleBestiary && rates.doubleBestiary && rates.doubleBestiary == currentEventRates.doubleBestiary) {
+				duplicatedRates[existingEventName].emplace_back("double-bestiary");
+				applyDoubleBestiary = false;
+			}
+			if (applyDoubleBosstiary && rates.doubleBossTiary && rates.doubleBossTiary == currentEventRates.doubleBossTiary) {
+				duplicatedRates[existingEventName].emplace_back("double-bosstiary");
+				applyDoubleBosstiary = false;
+			}
+			if (applyFastExercise && rates.fastExercise && rates.fastExercise == currentEventRates.fastExercise) {
+				duplicatedRates[existingEventName].emplace_back("fast-exercise");
+				applyFastExercise = false;
+			}
+			if (applyBossCooldown && rates.bosscooldown != 100 && rates.bosscooldown == currentEventRates.bosscooldown) {
+				duplicatedRates[existingEventName].emplace_back("bosscooldown");
+				applyBossCooldown = false;
+			}
+		}
+
+		if (applyExp) {
+			setExpSchedule(currentEventRates.exprate);
+		}
+		if (applyLoot) {
+			setLootSchedule(currentEventRates.lootrate);
+		}
+		if (applyBossLoot) {
+			setBossLootSchedule(currentEventRates.bosslootrate);
+		}
+		if (applySpawn) {
+			setSpawnMonsterSchedule(currentEventRates.spawnrate);
+		}
+		if (applySkill) {
+			setSkillSchedule(currentEventRates.skillrate);
+		}
+		if (applyFiendish) {
+			setFiendishSchedule(currentEventRates.fiendishrate);
+		}
+		if (applyInfluenced) {
+			setInfluencedSchedule(currentEventRates.influencedrate);
+		}
+		if (applyForge) {
+			g_kv().scoped("eventscheduler")->set("forge-chance", currentEventRates.forgeChance);
+		}
+		if (applyDoubleBestiary) {
+			g_kv().scoped("eventscheduler")->set("double-bestiary", true);
+		}
+		if (applyDoubleBosstiary) {
+			g_kv().scoped("eventscheduler")->set("double-bosstiary", true);
+		}
+		if (applyFastExercise) {
+			g_kv().scoped("eventscheduler")->set("fast-exercise", true);
+		}
+		if (applyBossCooldown) {
+			g_kv().scoped("eventscheduler")->set("boss-cooldown", currentEventRates.bosscooldown);
+		}
+
+		for (const auto &[duplicateEventName, rates] : duplicatedRates) {
+			if (!rates.empty()) {
+				std::string ratesString = join(rates, ", ");
+				g_logger().warn("{} - Events '{}' and '{}' have the same rates [{}] on the same day.", __FUNCTION__, eventName, duplicateEventName, ratesString);
+			}
+		}
+
+		eventsOnSameDay[eventName] = currentEventRates;
+		eventScheduler.emplace_back(EventScheduler { eventName, startTime, endTime });
+	}
+
+	for (const auto &event : eventScheduler) {
+		if (now >= event.startTime && now <= event.endTime) {
+			g_logger().info("Active EventScheduler: {}", event.name);
+		}
+	}
+	return true;
+}
 
 bool EventsScheduler::loadScheduleEventFromXml() {
 	pugi::xml_document doc;
-	auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
+	const auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
 	if (!doc.load_file(folder.c_str())) {
 		printXMLError(__FUNCTION__, folder, doc.load_file(folder.c_str()));
 		consoleHandlerExit();
 		return false;
 	}
 
-	time_t t = time(nullptr);
-	const tm* timePtr = localtime(&t);
-	int daysMath = ((timePtr->tm_year + 1900) * 365) + ((timePtr->tm_mon + 1) * 30) + (timePtr->tm_mday);
+	const auto now = getTimeNow();
 
-	// Keep track of loaded scripts to check for duplicates
-	phmap::flat_hash_set<std::string_view> loadedScripts;
+	phmap::flat_hash_set<std::string> loadedScripts;
 	std::map<std::string, EventRates> eventsOnSameDay;
 	for (const auto &eventNode : doc.child("events").children()) {
 		std::string eventScript = eventNode.attribute("script").as_string();
 		std::string eventName = eventNode.attribute("name").as_string();
 
-		int16_t startYear;
-		int16_t startMonth;
-		int16_t startDay;
-		int16_t endYear;
-		int16_t endMonth;
-		int16_t endDay;
-		sscanf(eventNode.attribute("startdate").as_string(), "%hd/%hd/%hd", &startMonth, &startDay, &startYear);
-		sscanf(eventNode.attribute("enddate").as_string(), "%hd/%hd/%hd", &endMonth, &endDay, &endYear);
-		int startDays = ((startYear * 365) + (startMonth * 30) + startDay);
-		int endDays = ((endYear * 365) + (endMonth * 30) + endDay);
-
-		if (daysMath < startDays || daysMath > endDays) {
+		const auto startDateAttr = eventNode.attribute("startdate");
+		const auto endDateAttr = eventNode.attribute("enddate");
+		if (startDateAttr.empty() || endDateAttr.empty()) {
+			g_logger().warn("{} - Missing 'startdate' or 'enddate' for event '{}'", __FUNCTION__, eventName);
 			continue;
 		}
 
-		if (!eventScript.empty() && loadedScripts.contains(eventScript)) {
-			g_logger().warn("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
+		std::string defaultHour = eventNode.attribute("hour").empty() ? std::string {} : eventNode.attribute("hour").as_string();
+		std::string startHour = eventNode.attribute("starthour").empty() ? (!defaultHour.empty() ? defaultHour : "00:00") : eventNode.attribute("starthour").as_string();
+		std::string endHour = eventNode.attribute("endhour").empty() ? (!defaultHour.empty() ? defaultHour : "23:59:59") : eventNode.attribute("endhour").as_string();
+		std::time_t startTime {};
+		std::time_t endTime {};
+		if (!parseDateTime(startDateAttr.as_string(), startHour, startTime) || !parseDateTime(endDateAttr.as_string(), endHour, endTime)) {
+			g_logger().warn("{} - Invalid date or hour format for event '{}'", __FUNCTION__, eventName);
+			continue;
+		}
+		if (endTime < startTime) {
+			g_logger().warn("{} - Event '{}' end time is before start time", __FUNCTION__, eventName);
 			continue;
 		}
 
-		loadedScripts.insert(eventScript);
-		if (!eventScript.empty() && !g_scripts().loadEventSchedulerScripts(eventScript)) {
-			g_logger().warn("{} - Can not load the file '{}' on '/events/scripts/scheduler/'", __FUNCTION__, eventScript);
-			return false;
+		if (now < startTime || now > endTime) {
+			continue;
+		}
+
+		if (!eventScript.empty()) {
+			if (loadedScripts.contains(eventScript)) {
+				g_logger().warn("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
+				continue;
+			}
+
+			loadedScripts.insert(eventScript);
+			if (!g_scripts().loadEventSchedulerScripts(eventScript)) {
+				g_logger().warn("{} - Cannot load the file '{}' on '/events/scripts/scheduler/'", __FUNCTION__, eventScript);
+				return false;
+			}
 		}
 
 		EventRates currentEventRates;
@@ -71,47 +369,47 @@ bool EventsScheduler::loadScheduleEventFromXml() {
 			if (ingameNode.attribute("exprate")) {
 				uint16_t exprate = static_cast<uint16_t>(ingameNode.attribute("exprate").as_uint());
 				currentEventRates.exprate = exprate;
-				g_eventsScheduler().setExpSchedule(exprate);
+				setExpSchedule(exprate);
 			}
 
 			if (ingameNode.attribute("lootrate")) {
 				uint16_t lootrate = static_cast<uint16_t>(ingameNode.attribute("lootrate").as_uint());
 				currentEventRates.lootrate = lootrate;
-				g_eventsScheduler().setLootSchedule(lootrate);
+				setLootSchedule(lootrate);
 			}
 
 			if (ingameNode.attribute("bosslootrate")) {
 				uint16_t bosslootrate = static_cast<uint16_t>(ingameNode.attribute("bosslootrate").as_uint());
 				currentEventRates.bosslootrate = bosslootrate;
-				g_eventsScheduler().setBossLootSchedule(bosslootrate);
+				setBossLootSchedule(bosslootrate);
 			}
 
 			if (ingameNode.attribute("spawnrate")) {
 				uint16_t spawnrate = static_cast<uint16_t>(ingameNode.attribute("spawnrate").as_uint());
 				currentEventRates.spawnrate = spawnrate;
-				g_eventsScheduler().setSpawnMonsterSchedule(spawnrate);
+				setSpawnMonsterSchedule(spawnrate);
 			}
 
 			if (ingameNode.attribute("skillrate")) {
 				uint16_t skillrate = static_cast<uint16_t>(ingameNode.attribute("skillrate").as_uint());
 				currentEventRates.skillrate = skillrate;
-				g_eventsScheduler().setSkillSchedule(skillrate);
+				setSkillSchedule(skillrate);
 			}
 
 			if (ingameNode.attribute("fiendishrate")) {
 				uint16_t fiendishrate = static_cast<uint16_t>(ingameNode.attribute("fiendishrate").as_uint());
 				currentEventRates.fiendishrate = fiendishrate;
-				g_eventsScheduler().setFiendishSchedule(fiendishrate);
+				setFiendishSchedule(fiendishrate);
 			}
 
 			if (ingameNode.attribute("influencedrate")) {
 				uint16_t influencedrate = static_cast<uint16_t>(ingameNode.attribute("influencedrate").as_uint());
 				currentEventRates.influencedrate = influencedrate;
-				g_eventsScheduler().setInfluencedSchedule(influencedrate);
+				setInfluencedSchedule(influencedrate);
 			}
 		}
 
-		for (const auto &[eventName, rates] : eventsOnSameDay) {
+		for (const auto &[existingName, rates] : eventsOnSameDay) {
 			std::vector<std::string> modifiedRates;
 
 			if (rates.exprate != 100 && currentEventRates.exprate != 100 && rates.exprate == currentEventRates.exprate) {
@@ -138,16 +436,16 @@ bool EventsScheduler::loadScheduleEventFromXml() {
 
 			if (!modifiedRates.empty()) {
 				std::string ratesString = join(modifiedRates, ", ");
-				g_logger().warn("{} - Events '{}' and '{}' have the same rates [{}] on the same day.", __FUNCTION__, eventNode.attribute("name").as_string(), eventName.c_str(), ratesString);
+				g_logger().warn("{} - Events '{}' and '{}' have the same rates [{}] on the same day.", __FUNCTION__, eventName, existingName, ratesString);
 			}
 		}
 
 		eventsOnSameDay[eventName] = currentEventRates;
-		eventScheduler.emplace_back(EventScheduler(eventName, startDays, endDays));
+		eventScheduler.emplace_back(EventScheduler { eventName, startTime, endTime });
 	}
 
 	for (const auto &event : eventScheduler) {
-		if (daysMath >= event.startDays && daysMath <= event.endDays) {
+		if (now >= event.startTime && now <= event.endTime) {
 			g_logger().info("Active EventScheduler: {}", event.name);
 		}
 	}

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -20,10 +20,14 @@
 #include "lib/di/container.hpp"
 #include "utils/tools.hpp"
 
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <ctime>
+#endif
+
 struct EventScheduler {
 	std::string name;
-	int startDays;
-	int endDays;
+	std::time_t startTime {};
+	std::time_t endTime {};
 };
 
 struct EventRates {
@@ -34,6 +38,11 @@ struct EventRates {
 	uint16_t skillrate = 100;
 	uint16_t fiendishrate = 100;
 	uint16_t influencedrate = 100;
+	uint8_t forgeChance = 100;
+	uint8_t bosscooldown = 100;
+	bool doubleBestiary {};
+	bool doubleBossTiary {};
+	bool fastExercise {};
 };
 
 class EventsScheduler {
@@ -48,7 +57,7 @@ public:
 		return inject<EventsScheduler>();
 	}
 
-	// Event schedule xml load
+	bool loadScheduleEventFromJson();
 	bool loadScheduleEventFromXml();
 
 	// Event schedule
@@ -100,6 +109,10 @@ public:
 	void setSkillSchedule(uint16_t skillrate) {
 		skillSchedule = (skillSchedule * skillrate) / 100;
 	}
+
+	void reset();
+
+	[[nodiscard]] std::vector<std::string> getActiveEvents() const;
 
 private:
 	// Event schedule

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -753,6 +753,14 @@ public:
 	bool canBeMoved() const;
 	void checkDecayMapItemOnMove();
 
+	void setActor(bool value) {
+		m_hasActor = value;
+	}
+
+	bool hasActor() const {
+		return m_hasActor;
+	}
+
 protected:
 	std::weak_ptr<Cylinder> m_parent;
 
@@ -762,6 +770,7 @@ protected:
 	bool loadedFromMap = false;
 	bool isLootTrackeable = false;
 	bool decayDisabled = false;
+	bool m_hasActor = false;
 
 private:
 	// Don't add variables here, use the ItemAttribute class.

--- a/src/lua/functions/items/item_functions.cpp
+++ b/src/lua/functions/items/item_functions.cpp
@@ -75,6 +75,7 @@ void ItemFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Item", "isOwner", ItemFunctions::luaItemIsOwner);
 	Lua::registerMethod(L, "Item", "getOwnerName", ItemFunctions::luaItemGetOwnerName);
 	Lua::registerMethod(L, "Item", "hasOwner", ItemFunctions::luaItemHasOwner);
+	Lua::registerMethod(L, "Item", "actor", ItemFunctions::luaItemActor);
 
 	Lua::registerMethod(L, "Item", "moveTo", ItemFunctions::luaItemMoveTo);
 	Lua::registerMethod(L, "Item", "transform", ItemFunctions::luaItemTransform);
@@ -1145,6 +1146,24 @@ int ItemFunctions::luaItemHasOwner(lua_State* L) {
 	}
 
 	Lua::pushBoolean(L, item->hasOwner());
+	return 1;
+}
+
+int ItemFunctions::luaItemActor(lua_State* L) {
+	// item:actor([value])
+	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	if (!item) {
+		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
+		return 1;
+	}
+
+	if (lua_gettop(L) == 1) {
+		Lua::pushBoolean(L, item->hasActor());
+	} else {
+		item->setActor(Lua::getBoolean(L, 2));
+		Lua::pushBoolean(L, true);
+	}
+
 	return 1;
 }
 

--- a/src/lua/functions/items/item_functions.hpp
+++ b/src/lua/functions/items/item_functions.hpp
@@ -98,6 +98,7 @@ private:
 	static int luaItemIsOwner(lua_State* L);
 	static int luaItemGetOwnerName(lua_State* L);
 	static int luaItemHasOwner(lua_State* L);
+	static int luaItemActor(lua_State* L);
 
 	static int luaItemSetShader(lua_State* L);
 	static int luaItemGetShader(lua_State* L);

--- a/src/lua/scripts/scripts.cpp
+++ b/src/lua/scripts/scripts.cpp
@@ -50,6 +50,24 @@ void Scripts::clearAllScripts() const {
 	g_monsters().clear();
 }
 
+bool Scripts::loadEventSchedulerScripts(const std::filesystem::path &filePath) {
+	if (!std::filesystem::exists(filePath) || !std::filesystem::is_regular_file(filePath)) {
+		g_logger().warn("{} - Cannot load file '{}'", __FUNCTION__, filePath.string());
+		return false;
+	}
+
+	if (filePath.extension() == ".lua") {
+		if (scriptInterface.loadFile(filePath.string(), filePath.filename().string()) == -1) {
+			g_logger().error(filePath.string());
+			g_logger().error(scriptInterface.getLastLuaError());
+			return false;
+		}
+		return true;
+	}
+
+	return false;
+}
+
 bool Scripts::loadEventSchedulerScripts(const std::string &fileName) {
 	auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
 	const auto dir = std::filesystem::current_path() / coreFolder / "events" / "scripts" / "scheduler";

--- a/src/lua/scripts/scripts.hpp
+++ b/src/lua/scripts/scripts.hpp
@@ -30,6 +30,7 @@ public:
 	void clearAllScripts() const;
 
 	bool loadEventSchedulerScripts(const std::string &fileName);
+	bool loadEventSchedulerScripts(const std::filesystem::path &filePath);
 	bool loadScripts(std::string_view folderName, bool isLib, bool reload);
 	LuaScriptInterface &getScriptInterface() {
 		return scriptInterface;


### PR DESCRIPTION
- Introduce JSON-driven event scheduling: add data/json/eventscheduler/events.json and EventsScheduler::loadScheduleEventFromJson() to load/validate events, parse dates/times, enforce active-only loading, detect duplicated rate declarations, and apply schedules to runtime KV/state. 
- Refactor XML loader to use the same date/time parsing and time-based checks, replace day-count math with std::time_t, and log active events.
- Add EventsScheduler::reset() and getActiveEvents(), extend EventScheduler/EventRates to use time_t and new rate flags, and register the JSON loader in CrystalServer. 
- Also add Scripts overload to load scheduler scripts from a filesystem::path and adjust headers/includes accordingly.
- Fixed exercise training actor