### PR TITLE
fix: Avoid teleporting staff to Newhaven on login/death

### DIFF
--- a/data-global/scripts/custom/newhaven/on_death_newhaven.lua
+++ b/data-global/scripts/custom/newhaven/on_death_newhaven.lua
@@ -2,7 +2,7 @@ local onDeathNewhaven = CreatureEvent("onDeathNewhaven")
 
 function onDeathNewhaven.onDeath(creature, corpse, killer, mostDamage, unjustified, mostDamageUnjustified)
 	if creature and creature:isPlayer() then
-		if creature:getVocation():getId() == VOCATION_NONE then
+		if creature:getVocation():getId() == VOCATION_NONE and not creature:getGroup():getAccess() then
 			creature:teleportTo(Position(32534, 32513, 7))
 			creature:setStorageValue(Storage.Quest.U15_12.newhavenCitizen, 1)
 			return true

--- a/data-global/scripts/custom/newhaven/on_login_newhaven.lua
+++ b/data-global/scripts/custom/newhaven/on_login_newhaven.lua
@@ -5,9 +5,11 @@ function newhavenOnLogin.onLogin(player)
 		return false
 	end
 
-	if player:getVocation():getId() == VOCATION_NONE then
-		player:teleportTo(Position(32534, 32513, 7))
-		player:setStorageValue(Storage.Quest.U15_12.newhavenCitizen, 1)
+	if player:getVocation():getId() == VOCATION_NONE and not player:getGroup():getAccess() then
+		if player:getStorageValue(Storage.Quest.U15_12.newhavenCitizen) <= 0 then
+			player:teleportTo(Position(32534, 32513, 7))
+			player:setStorageValue(Storage.Quest.U15_12.newhavenCitizen, 1)
+		end
 	end
 
 	if player:getStorageValue(Storage.Quest.U15_12.newhavenCitizen) == 1 then


### PR DESCRIPTION
- Add group-access guard to on_death_newhaven and on_login_newhaven so characters with staff access are not auto-teleported when they have VOCATION_NONE. 
- On login, also add a storage check (Storage.Quest.U15_12.newhavenCitizen <= 0) so the teleport only happens once, preventing repeated/looping teleports for the same player.