### PR TITLE
fix: In Service of Yalahar Quest

### DIFF
--- a/data-global/scripts/quests/in_service_of_yalahar/creaturescritps_quara_leader_kill.lua
+++ b/data-global/scripts/quests/in_service_of_yalahar/creaturescritps_quara_leader_kill.lua
@@ -12,7 +12,7 @@ function quaraLeadersKill.onDeath(creature)
 	end
 
 	onDeathForDamagingPlayers(creature, function(creature, player)
-		if player:getStorageValue(bossStorage) < 1 then
+		if player:getStorageValue(bossStorage) < 1 and player:getStorageValue(Storage.Quest.U8_4.InServiceOfYalahar.Mission07) < 5 then
 			player:setStorageValue(bossStorage, 1)
 			player:say("You slayed " .. creature:getName() .. ".", TALKTYPE_MONSTER_SAY)
 			player:setStorageValue(Storage.Quest.U8_4.InServiceOfYalahar.QuaraState, 2)


### PR DESCRIPTION
Add a check to boss kill, if quest already complete will do nothing. If you complete the quest and kill those bosses by accident after, you will bug your progress into the quest by setting a diferent questline avoiding progress in steps like going into the inner city for final mission or things like that.

The quara state, questline and mission 7 will update only if you mission07 is < 5, meaning that if you completed the mission >= 5 it won't do nothing and won't bug your questlog and progress.

Also renamed the file for an easier indentification.