### PR TITLE
feat: add "Bounty Task" and "Weekly Task" completion banners

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -8490,6 +8490,18 @@ void Player::sendScreenshotAndBannerUnlockedSpell(uint16_t spellId) const {
 	}
 }
 
+void Player::sendScreenshotAndBannerBountyTaskFinished(uint16_t raceId) const {
+	if (client) {
+		client->sendScreenshotAndBannerBountyTaskFinished(raceId);
+	}
+}
+
+void Player::sendScreenshotAndBannerWeeklyTaskSpecificFinished(uint16_t raceId) const {
+	if (client) {
+		client->sendScreenshotAndBannerWeeklyTaskSpecificFinished(raceId);
+	}
+}
+
 void Player::checkSpellUnlocksOnAdvance(uint32_t oldLevel, uint32_t newLevel, uint32_t oldMagLevel, uint32_t newMagLevel) const {
 	if (!client) {
 		return;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1189,6 +1189,8 @@ public:
 	// Shows the "New Spell Unlocked" banner for vocation spells that auto-unlock
 	// when the player crosses their required level / magic level on advance.
 	void checkSpellUnlocksOnAdvance(uint32_t oldLevel, uint32_t newLevel, uint32_t oldMagLevel, uint32_t newMagLevel) const;
+	void sendScreenshotAndBannerBountyTaskFinished(uint16_t raceId) const;
+	void sendScreenshotAndBannerWeeklyTaskSpecificFinished(uint16_t raceId) const;
 
 	void onThink(uint32_t interval) override;
 

--- a/src/io/iobountytasks.cpp
+++ b/src/io/iobountytasks.cpp
@@ -526,6 +526,7 @@ void IOBountyTasks::onCreatureKill(const std::shared_ptr<Player> &player, uint16
 	if (bountyData.activeTask.currentKills >= bountyData.activeTask.requiredKills) {
 		bountyData.state = BOUNTY_STATE_COMPLETED;
 		player->sendTextMessage(MESSAGE_STATUS, "You have completed your bounty task! Claim your reward.");
+		player->sendScreenshotAndBannerBountyTaskFinished(bountyData.activeTask.raceId);
 	}
 
 	player->sendBountyTaskData();

--- a/src/io/ioweeklytasks.cpp
+++ b/src/io/ioweeklytasks.cpp
@@ -262,6 +262,7 @@ void IOWeeklyTasks::onCreatureKill(const std::shared_ptr<Player> &player, uint16
 				player->addExperience(nullptr, weeklyData.killTaskRewardExp, false);
 
 				player->sendTextMessage(MESSAGE_STATUS, "You have completed a weekly kill task!");
+				player->sendScreenshotAndBannerWeeklyTaskSpecificFinished(task.raceId);
 				recalculateWeeklyRewardValues(player);
 				player->refreshTaskIcons();
 			}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -10823,6 +10823,34 @@ void ProtocolGame::sendScreenshotAndBannerUnlockedSpell(uint16_t spellId) {
 	writeToOutputBuffer(msg);
 }
 
+void ProtocolGame::sendScreenshotAndBannerBountyTaskFinished(uint16_t raceId) {
+	if (oldProtocol) {
+		return;
+	}
+
+	// Client GameEventTypeBountyTaskFinished: the creature race id is sent as a
+	// uint16; the client resolves it to the creature name ("Completed task: ...").
+	NetworkMessage msg;
+	msg.addByte(0x75);
+	msg.addByte(SCREENSHOT_AND_BANNER_TYPE_BOUNTY_TASK);
+	msg.add<uint16_t>(raceId);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGame::sendScreenshotAndBannerWeeklyTaskSpecificFinished(uint16_t raceId) {
+	if (oldProtocol) {
+		return;
+	}
+
+	// Client GameEventTypeWeeklyTaskSpecificCreatureFinished: the creature race id
+	// is sent as a uint16; the client resolves it to the creature name.
+	NetworkMessage msg;
+	msg.addByte(0x75);
+	msg.addByte(SCREENSHOT_AND_BANNER_TYPE_WEEKLY_TASK_SPECIFIC);
+	msg.add<uint16_t>(raceId);
+	writeToOutputBuffer(msg);
+}
+
 void ProtocolGame::sendOutfitWindowCustomOTCR(NetworkMessage &msg) {
 	if (!isOTCR) {
 		return;

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -622,6 +622,8 @@ private:
 	void sendScreenshotAndBannerProgressQuest(const std::string &questName, bool isCompleted);
 	void sendScreenshotAndBannerProficiencyProgress(uint16_t itemId, const std::string &message);
 	void sendScreenshotAndBannerUnlockedSpell(uint16_t spellId);
+	void sendScreenshotAndBannerBountyTaskFinished(uint16_t raceId);
+	void sendScreenshotAndBannerWeeklyTaskSpecificFinished(uint16_t raceId);
 
 	void sendDisableLoginMusic();
 


### PR DESCRIPTION
Adds the banners the 15.x client shows when a player finishes a Bounty task
or a Weekly specific-creature kill task ("Completed task: <creature>").

## Preview

**Bounty Task**

![Bounty Task](https://raw.githubusercontent.com/Mckay666/crystalserver/pr-assets/docs/banners/bounty.png)

**Weekly Task**

![Weekly Task](https://raw.githubusercontent.com/Mckay666/crystalserver/pr-assets/docs/banners/weekly.png)