### PR TITLE
perf(lua): harden shared userdata and reduce refcount churn

### DIFF
--- a/cmake/modules/CrystalLib.cmake
+++ b/cmake/modules/CrystalLib.cmake
@@ -33,6 +33,10 @@ endif()
 # *****************************************************************************
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(${PROJECT_NAME}_lib PRIVATE -Wno-deprecated-declarations)
+elseif (MSVC)
+    # Legacy Lua userdata helpers are intentionally kept and marked [[deprecated]];
+    # suppress C4996 so the still-valid core-type bindings do not flood the build.
+    target_compile_options(${PROJECT_NAME}_lib PRIVATE /wd4996)
 endif()
 
 # Sets the NDEBUG macro for Release and RelWithDebInfo configurations.

--- a/docs/systems/lua-shared-userdata.md
+++ b/docs/systems/lua-shared-userdata.md
@@ -1,0 +1,168 @@
+# Lua shared userdata ownership
+
+Crystal Server Lua bindings can expose C++ objects as full userdata. When the userdata
+stores a `std::shared_ptr<T>`, the userdata memory contains a non-trivial C++
+object that was constructed with placement-new. Lua owns the userdata memory,
+but it does not know how to destroy the C++ `std::shared_ptr<T>` object unless
+the userdata metatable has a matching `__gc` finalizer.
+
+## What went wrong
+
+The dangerous pattern is:
+
+```cpp
+Lua::pushUserdata<T>(L, sharedPtr);
+Lua::setMetatable(L, -1, "TypeName");
+```
+
+`pushUserdata<T>(..., std::shared_ptr<T>)` constructs a `std::shared_ptr<T>`
+inside Lua userdata. If the metatable does not register `__gc`, Lua can collect
+the userdata block without running the `std::shared_ptr<T>` destructor. The
+reference count is never decremented, the control block remains allocated, and
+the pointed object can stay alive permanently.
+
+This is especially easy to miss because `collectgarbage("collect")` may keep
+Lua memory stable while process RSS keeps growing in the C++ heap.
+
+The bug was observed in these high-risk bindings:
+
+- `KV`: `kv:scoped()` and `player:kv()` registered the class with the plain
+  `registerClass` helper (no `__gc` at all), so scoped KV objects were retained
+  indefinitely.
+- `Condition`: `creature:getCondition()` returned shared userdata through a
+  weak metatable. `setWeakMetatable` removes `__gc`; it does not store a real
+  `std::weak_ptr`.
+- `NetworkMessage`: module receive-byte callbacks wrapped a borrowed
+  `NetworkMessage&` in `std::shared_ptr<NetworkMessage>(&msg)`. Without a
+  no-op deleter and typed finalizer, this could leak the control block and made
+  `networkMessage:delete()` unsafe for borrowed messages.
+
+## Current contract
+
+Shared userdata must use the typed helpers in
+`src/lua/functions/lua_functions_loader.hpp`:
+
+```cpp
+template <>
+struct LuaUserdataTraits<MyType> {
+	static constexpr std::string_view name = "MyType";
+};
+
+Lua::registerSharedClass<MyType>(L, "", MyTypeFunctions::luaMyTypeCreate);
+Lua::pushSharedUserdata<MyType>(L, mySharedPtr);
+```
+
+The trait is intentionally required. It keeps the C++ type, Lua metatable name,
+and `__gc` finalizer tied together at compile time.
+
+For borrowed callback objects, use:
+
+```cpp
+Lua::pushBorrowedSharedUserdata<MyType>(L, borrowedObject);
+```
+
+This creates a `std::shared_ptr<T>` with a no-op deleter and still uses the
+typed `__gc` finalizer to destroy only the `std::shared_ptr<T>` stored in the
+userdata. It prevents invalid `delete` and releases the control block. It does
+not make the borrowed object safe to store after the callback returns.
+
+## Rules
+
+- Do not combine `pushUserdata<T>(..., std::shared_ptr<T>)` with a manual
+  `setMetatable`.
+- Do not use `setWeakMetatable` for userdata that stores `std::shared_ptr<T>`.
+  It disables `__gc` and can leak the stored C++ object.
+- Do not wrap borrowed objects with `std::shared_ptr<T>(&object)` unless a
+  no-op deleter is used. Prefer `pushBorrowedSharedUserdata<T>`.
+- Do not register new shared userdata with the untyped
+  `registerSharedClass(lua_State*, className, baseClass, ctor)` overload.
+  Prefer `registerSharedClass<T>`.
+- Add a `LuaUserdataTraits<T>` specialization before pushing or registering a
+  new shared userdata type.
+- Use `pushSharedUserdata<T>` only for non-const `std::shared_ptr<T>`. If a Lua
+  API needs a read-only object, introduce a separate read-only metatable instead
+  of pushing `std::shared_ptr<const T>` through the normal mutable metatable.
+
+## Review checklist
+
+When reviewing Lua binding changes, check for:
+
+```sh
+rg -n "pushUserdata<.*std::shared_ptr|setWeakMetatable|std::shared_ptr<[^>]+>\\(&" src/lua
+rg -n "registerSharedClass\\(L," src/lua
+```
+
+Any match must be justified. New shared userdata should normally use
+`LuaUserdataTraits<T>`, `registerSharedClass<T>`, `pushSharedUserdata<T>`, or
+`pushBorrowedSharedUserdata<T>`.
+
+## What this change fixes
+
+The typed shared userdata helpers make the finalizer use the real C++ type:
+
+```cpp
+const std::string metatableName(getUserdataMetatableName<T>());
+auto objPtr = static_cast<std::shared_ptr<T>*>(luaL_testudata(L, 1, metatableName.c_str()));
+if (!objPtr) {
+	objPtr = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+}
+std::destroy_at(objPtr);
+std::construct_at(objPtr);
+```
+
+That runs the `std::shared_ptr<T>` destructor, decrements the reference count,
+and then leaves an empty `std::shared_ptr<T>` in the userdata slot. Rebuilding
+the empty value mirrors the existing defensive pattern used by other userdata
+cleanup code and reduces the impact of accidental repeated cleanup.
+
+The change also migrates the critical `KV`, `Condition`, and `NetworkMessage`
+bindings to the typed path.
+
+## Follow-up hardening
+
+After the critical leak fixes, the next risky pattern was the legacy shared
+class registration:
+
+```cpp
+Lua::registerSharedClass(L, "TypeName", "", TypeFunctions::luaCreate);
+```
+
+That overload installs `Lua::luaGarbageCollection`, which treats the userdata as
+`std::shared_ptr<SharedObject>`. This is not correct for userdata that actually
+stores `std::shared_ptr<T>` where `T` does not inherit from `SharedObject`.
+
+The non-`SharedObject` shared userdata bindings were migrated to typed
+finalizers as well:
+
+- `Action`
+- `Charm`
+- `Combat`
+- `CreatureEvent`
+- `EventCallback`
+- `GlobalEvent`
+- `Group`
+- `Guild`
+- `Loot`
+- `ModalWindow`
+- `MonsterSpell`
+- `MonsterType`
+- `Mount`
+- `Shop`
+- `Spell`
+- `TalkAction`
+- `Town`
+- `Vocation`
+- `Weapon`
+- `Zone`
+
+Some legacy `registerSharedClass(L, ...)` calls can still exist for userdata
+whose stored type is part of the `SharedObject` hierarchy, and `Position` is a
+Lua table rather than a shared userdata object. New code should still prefer the
+typed helpers.
+
+Do not mechanically migrate polymorphic core userdata such as `Creature`,
+`Player`, `Monster`, `Npc`, `Item`, `Container`, `Tile`, or `Teleport` without a
+separate audit. Those paths can push a userdata that stores a base
+`std::shared_ptr<T>` and then assign a more specific Lua metatable. A typed
+finalizer is only correct when the finalizer type matches the actual
+`std::shared_ptr<T>` object stored in the userdata slot.

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -103,16 +103,34 @@ public:
 	virtual std::shared_ptr<const Player> getPlayer() const {
 		return nullptr;
 	}
+	virtual Player* getPlayerRaw() noexcept {
+		return nullptr;
+	}
+	virtual const Player* getPlayerRaw() const noexcept {
+		return nullptr;
+	}
 	virtual std::shared_ptr<Npc> getNpc() {
 		return nullptr;
 	}
 	virtual std::shared_ptr<const Npc> getNpc() const {
 		return nullptr;
 	}
+	virtual Npc* getNpcRaw() noexcept {
+		return nullptr;
+	}
+	virtual const Npc* getNpcRaw() const noexcept {
+		return nullptr;
+	}
 	virtual std::shared_ptr<Monster> getMonster() {
 		return nullptr;
 	}
 	virtual std::shared_ptr<const Monster> getMonster() const {
+		return nullptr;
+	}
+	virtual Monster* getMonsterRaw() noexcept {
+		return nullptr;
+	}
+	virtual const Monster* getMonsterRaw() const noexcept {
 		return nullptr;
 	}
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -577,12 +577,12 @@ void Monster::onSpawn(const Position &position) {
 }
 
 void Monster::addFriend(const std::shared_ptr<Creature> &creature) {
-	if (creature == getMonster()) {
+	if (creature.get() == this) {
 		g_logger().error("[{}]: adding creature is same of monster", __FUNCTION__);
 		return;
 	}
 
-	assert(creature != getMonster());
+	assert(creature.get() != this);
 	friendList.try_emplace(creature->getID(), creature);
 }
 
@@ -594,12 +594,12 @@ void Monster::removeFriend(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Monster::addTarget(const std::shared_ptr<Creature> &creature, bool pushFront /* = false*/) {
-	if (creature == getMonster()) {
+	if (creature.get() == this) {
 		g_logger().error("[{}]: adding creature is same of monster", __FUNCTION__);
 		return false;
 	}
 
-	assert(creature != getMonster());
+	assert(creature.get() != this);
 
 	auto it = getTargetIterator(creature);
 	if (it != targetList.end()) {
@@ -790,7 +790,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	for (const auto &cref : targetList) {
 		const auto &creature = cref.lock();
 		if (creature && isTarget(creature)) {
-			if ((static_self_cast<Monster>()->targetDistance == 1) || canUseAttack(myPos, creature)) {
+			if ((targetDistance == 1) || canUseAttack(myPos, creature)) {
 				resultList.emplace_back(creature);
 			}
 		}

--- a/src/creatures/monsters/monster.hpp
+++ b/src/creatures/monsters/monster.hpp
@@ -42,6 +42,12 @@ public:
 
 	std::shared_ptr<Monster> getMonster() override;
 	std::shared_ptr<const Monster> getMonster() const override;
+	Monster* getMonsterRaw() noexcept override {
+		return this;
+	}
+	const Monster* getMonsterRaw() const noexcept override {
+		return this;
+	}
 
 	void setID() override;
 

--- a/src/creatures/npcs/npc.hpp
+++ b/src/creatures/npcs/npc.hpp
@@ -45,6 +45,12 @@ public:
 
 	std::shared_ptr<Npc> getNpc() override;
 	std::shared_ptr<const Npc> getNpc() const override;
+	Npc* getNpcRaw() noexcept override {
+		return this;
+	}
+	const Npc* getNpcRaw() const noexcept override {
+		return this;
+	}
 
 	void setID() override;
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -284,6 +284,12 @@ public:
 	std::shared_ptr<const Player> getPlayer() const override {
 		return static_self_cast<Player>();
 	}
+	Player* getPlayerRaw() noexcept override {
+		return this;
+	}
+	const Player* getPlayerRaw() const noexcept override {
+		return this;
+	}
 
 	ExivaRestrictions &getExivaRestrictions();
 	const ExivaRestrictions &getExivaRestrictions() const;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1304,14 +1304,19 @@ bool Game::removeCreature(const std::shared_ptr<Creature> &creature, bool isLogo
 	auto fromZones = creature->getZones();
 
 	if (tile) {
-		std::vector<int32_t> oldStackPosVector;
 		auto spectators = Spectators().find<Creature>(tile->getPosition(), true);
-		auto playersSpectators = spectators.filter<Player>();
-
-		for (const auto &spectator : playersSpectators) {
-			if (const auto &player = spectator->getPlayer()) {
-				oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getStackposOfCreature(player, creature) : -1);
+		std::vector<Player*> playerSpectators;
+		playerSpectators.reserve(spectators.size());
+		for (const auto &spectator : spectators) {
+			if (auto* player = spectator->getPlayerRaw()) {
+				playerSpectators.emplace_back(player);
 			}
+		}
+
+		std::vector<int32_t> oldStackPosVector;
+		oldStackPosVector.reserve(playerSpectators.size());
+		for (const auto* player : playerSpectators) {
+			oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getStackposOfCreature(player, creature) : -1);
 		}
 
 		tile->removeCreature(creature);
@@ -1320,10 +1325,8 @@ bool Game::removeCreature(const std::shared_ptr<Creature> &creature, bool isLogo
 
 		// Send to client
 		size_t i = 0;
-		for (const auto &spectator : playersSpectators) {
-			if (const auto &player = spectator->getPlayer()) {
-				player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
-			}
+		for (const auto* player : playerSpectators) {
+			player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
 		}
 
 		// event method

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1404,7 +1404,11 @@ int32_t Tile::getThingIndex(const std::shared_ptr<Thing> &thing) const {
 	return -1;
 }
 
-int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+int32_t Tile::getClientIndexOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const {
+	if (!player) {
+		return -1;
+	}
+
 	int32_t n;
 	if (ground) {
 		n = 1;
@@ -1429,7 +1433,15 @@ int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, co
 	return -1;
 }
 
-int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+	return getClientIndexOfCreature(player.get(), creature);
+}
+
+int32_t Tile::getStackposOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const {
+	if (!player) {
+		return -1;
+	}
+
 	int32_t n;
 	if (ground) {
 		n = 1;
@@ -1457,6 +1469,10 @@ int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const
 		}
 	}
 	return -1;
+}
+
+int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+	return getStackposOfCreature(player.get(), creature);
 }
 
 int32_t Tile::getStackposOfItem(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item) const {

--- a/src/items/tile.hpp
+++ b/src/items/tile.hpp
@@ -30,6 +30,7 @@ class Zone;
 class Cylinder;
 class Item;
 class ItemType;
+class Player;
 
 using CreatureVector = std::vector<std::shared_ptr<Creature>>;
 using ItemVector = std::vector<std::shared_ptr<Item>>;
@@ -208,7 +209,9 @@ public:
 
 	std::string getDescription(int32_t lookDistance) final;
 
+	int32_t getClientIndexOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const;
+	int32_t getStackposOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getStackposOfItem(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item) const;
 

--- a/src/lua/callbacks/event_callback.cpp
+++ b/src/lua/callbacks/event_callback.cpp
@@ -1208,8 +1208,7 @@ bool EventCallback::zoneBeforeCreatureEnter(const std::shared_ptr<Zone> &zone, c
 	lua_State* L = getScriptInterface()->getLuaState();
 	getScriptInterface()->pushFunction(getScriptId());
 
-	LuaScriptInterface::pushUserdata<Zone>(L, zone);
-	LuaScriptInterface::setMetatable(L, -1, "Zone");
+	LuaScriptInterface::pushSharedUserdata<Zone>(L, zone);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
@@ -1232,8 +1231,7 @@ bool EventCallback::zoneBeforeCreatureLeave(const std::shared_ptr<Zone> &zone, c
 	lua_State* L = getScriptInterface()->getLuaState();
 	getScriptInterface()->pushFunction(getScriptId());
 
-	LuaScriptInterface::pushUserdata<Zone>(L, zone);
-	LuaScriptInterface::setMetatable(L, -1, "Zone");
+	LuaScriptInterface::pushSharedUserdata<Zone>(L, zone);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
@@ -1256,8 +1254,7 @@ void EventCallback::zoneAfterCreatureEnter(const std::shared_ptr<Zone> &zone, co
 	lua_State* L = getScriptInterface()->getLuaState();
 	getScriptInterface()->pushFunction(getScriptId());
 
-	LuaScriptInterface::pushUserdata<Zone>(L, zone);
-	LuaScriptInterface::setMetatable(L, -1, "Zone");
+	LuaScriptInterface::pushSharedUserdata<Zone>(L, zone);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
@@ -1280,8 +1277,7 @@ void EventCallback::zoneAfterCreatureLeave(const std::shared_ptr<Zone> &zone, co
 	lua_State* L = getScriptInterface()->getLuaState();
 	getScriptInterface()->pushFunction(getScriptId());
 
-	LuaScriptInterface::pushUserdata<Zone>(L, zone);
-	LuaScriptInterface::setMetatable(L, -1, "Zone");
+	LuaScriptInterface::pushSharedUserdata<Zone>(L, zone);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -194,8 +194,7 @@ int GameFunctions::luaGameCreateMonsterType(lua_State* L) {
 			}
 		}
 
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -343,8 +342,7 @@ int GameFunctions::luaGameGetMonstersByRace(lua_State* L) {
 	lua_createtable(L, monstersByRace.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByRace) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -357,8 +355,7 @@ int GameFunctions::luaGameGetMonstersByBestiaryStars(lua_State* L) {
 	lua_createtable(L, monstersByStars.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByStars) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -427,8 +424,7 @@ int GameFunctions::luaGameGetMonsterTypes(lua_State* L) {
 	lua_createtable(L, type.size(), 0);
 
 	for (const auto &[typeName, mType] : type) {
-		Lua::pushUserdata<MonsterType>(L, mType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, mType);
 		lua_setfield(L, -2, typeName.c_str());
 	}
 	return 1;
@@ -441,8 +437,7 @@ int GameFunctions::luaGameGetTowns(lua_State* L) {
 
 	int index = 0;
 	for (const auto &townEntry : towns) {
-		Lua::pushUserdata<Town>(L, townEntry.second);
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, townEntry.second);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -734,8 +729,7 @@ int GameFunctions::luaGameGetBestiaryCharm(lua_State* L) {
 
 	int index = 0;
 	for (const auto &charmPtr : c_list) {
-		Lua::pushUserdata<Charm>(L, charmPtr);
-		Lua::setMetatable(L, -1, "Charm");
+		Lua::pushSharedUserdata<Charm>(L, charmPtr);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -744,8 +738,7 @@ int GameFunctions::luaGameGetBestiaryCharm(lua_State* L) {
 int GameFunctions::luaGameCreateBestiaryCharm(lua_State* L) {
 	// Game.createBestiaryCharm(id)
 	if (const std::shared_ptr<Charm> &charm = g_iobestiary().getBestiaryCharm(static_cast<charmRune_t>(Lua::getNumber<int8_t>(L, 1, 0)), true)) {
-		Lua::pushUserdata<Charm>(L, charm);
-		Lua::setMetatable(L, -1, "Charm");
+		Lua::pushSharedUserdata<Charm>(L, charm);
 	} else {
 		lua_pushnil(L);
 	}
@@ -989,8 +982,7 @@ int GameFunctions::luaGameGetTalkActions(lua_State* L) {
 	lua_createtable(L, static_cast<int>(talkactionsMap.size()), 0);
 
 	for (const auto &[talkName, talkactionSharedPtr] : talkactionsMap) {
-		Lua::pushUserdata<TalkAction>(L, talkactionSharedPtr);
-		Lua::setMetatable(L, -1, "TalkAction");
+		Lua::pushSharedUserdata<TalkAction>(L, talkactionSharedPtr);
 		lua_setfield(L, -2, talkName.c_str());
 	}
 	return 1;

--- a/src/lua/functions/core/game/modal_window_functions.cpp
+++ b/src/lua/functions/core/game/modal_window_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ModalWindowFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "ModalWindow", "", ModalWindowFunctions::luaModalWindowCreate);
+	Lua::registerSharedClass<ModalWindow>(L, "", ModalWindowFunctions::luaModalWindowCreate);
 	Lua::registerMetaMethod(L, "ModalWindow", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "ModalWindow", "getId", ModalWindowFunctions::luaModalWindowGetId);
@@ -57,8 +57,7 @@ int ModalWindowFunctions::luaModalWindowCreate(lua_State* L) {
 	const std::string &title = Lua::getString(L, 3);
 	uint32_t id = Lua::getNumber<uint32_t>(L, 2);
 
-	Lua::pushUserdata<ModalWindow>(L, std::make_shared<ModalWindow>(id, title, message));
-	Lua::setMetatable(L, -1, "ModalWindow");
+	Lua::pushSharedUserdata<ModalWindow>(L, std::make_shared<ModalWindow>(id, title, message));
 	return 1;
 }
 

--- a/src/lua/functions/core/game/zone_functions.cpp
+++ b/src/lua/functions/core/game/zone_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ZoneFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Zone", "", ZoneFunctions::luaZoneCreate);
+	Lua::registerSharedClass<Zone>(L, "", ZoneFunctions::luaZoneCreate);
 	Lua::registerMetaMethod(L, "Zone", "__eq", ZoneFunctions::luaZoneCompare);
 
 	Lua::registerMethod(L, "Zone", "getName", ZoneFunctions::luaZoneGetName);
@@ -58,8 +58,7 @@ int ZoneFunctions::luaZoneCreate(lua_State* L) {
 	if (!zone) {
 		zone = Zone::addZone(name);
 	}
-	Lua::pushUserdata<Zone>(L, zone);
-	Lua::setMetatable(L, -1, "Zone");
+	Lua::pushSharedUserdata<Zone>(L, zone);
 	return 1;
 }
 
@@ -336,8 +335,7 @@ int ZoneFunctions::luaZoneGetByName(lua_State* L) {
 		lua_pushnil(L);
 		return 1;
 	}
-	Lua::pushUserdata<Zone>(L, zone);
-	Lua::setMetatable(L, -1, "Zone");
+	Lua::pushSharedUserdata<Zone>(L, zone);
 	return 1;
 }
 
@@ -354,8 +352,7 @@ int ZoneFunctions::luaZoneGetByPosition(lua_State* L) {
 	lua_createtable(L, static_cast<int>(zones.size()), 0);
 	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;
@@ -368,8 +365,7 @@ int ZoneFunctions::luaZoneGetAll(lua_State* L) {
 	int index = 0;
 	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;

--- a/src/lua/functions/core/libs/kv_functions.cpp
+++ b/src/lua/functions/core/libs/kv_functions.cpp
@@ -31,7 +31,7 @@ void KVFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "kv", "keys", KVFunctions::luaKVKeys);
 	Lua::registerMethod(L, "kv", "remove", KVFunctions::luaKVRemove);
 
-	Lua::registerClass(L, "KV", "");
+	Lua::registerSharedClass<KV>(L, "");
 	Lua::registerMethod(L, "KV", "scoped", KVFunctions::luaKVScoped);
 	Lua::registerMethod(L, "KV", "set", KVFunctions::luaKVSet);
 	Lua::registerMethod(L, "KV", "get", KVFunctions::luaKVGet);
@@ -46,14 +46,12 @@ int KVFunctions::luaKVScoped(lua_State* L) {
 	if (Lua::isUserdata(L, 1)) {
 		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1);
 		const auto &newScope = scopedKV->scoped(key);
-		Lua::pushUserdata<KV>(L, newScope);
-		Lua::setMetatable(L, -1, "KV");
+		Lua::pushSharedUserdata<KV>(L, newScope);
 		return 1;
 	}
 
 	const auto &scopedKV = g_kv().scoped(key);
-	Lua::pushUserdata<KV>(L, scopedKV);
-	Lua::setMetatable(L, -1, "KV");
+	Lua::pushSharedUserdata<KV>(L, scopedKV);
 	return 1;
 }
 

--- a/src/lua/functions/core/network/network_message_functions.cpp
+++ b/src/lua/functions/core/network/network_message_functions.cpp
@@ -17,15 +17,19 @@
 
 #include "lua/functions/core/network/network_message_functions.hpp"
 
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <memory>
+#endif
+
 #include "server/network/protocol/protocolgame.hpp"
 #include "creatures/players/player.hpp"
 #include "server/network/protocol/protocolstatus.hpp"
 #include "lua/functions/lua_functions_loader.hpp"
 
 void NetworkMessageFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "NetworkMessage", "", NetworkMessageFunctions::luaNetworkMessageCreate);
+	Lua::registerSharedClass<NetworkMessage>(L, "", NetworkMessageFunctions::luaNetworkMessageCreate);
 	Lua::registerMetaMethod(L, "NetworkMessage", "__eq", Lua::luaUserdataCompare);
-	Lua::registerMethod(L, "NetworkMessage", "delete", Lua::luaGarbageCollection);
+	Lua::registerMethod(L, "NetworkMessage", "delete", Lua::luaSharedPtrGarbageCollection<NetworkMessage>);
 
 	Lua::registerMethod(L, "NetworkMessage", "getByte", NetworkMessageFunctions::luaNetworkMessageGetByte);
 	Lua::registerMethod(L, "NetworkMessage", "getU16", NetworkMessageFunctions::luaNetworkMessageGetU16);
@@ -56,8 +60,7 @@ void NetworkMessageFunctions::init(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageCreate(lua_State* L) {
 	// NetworkMessage()
-	Lua::pushUserdata<NetworkMessage>(L, std::make_shared<NetworkMessage>());
-	Lua::setMetatable(L, -1, "NetworkMessage");
+	Lua::pushSharedUserdata<NetworkMessage>(L, std::make_shared<NetworkMessage>());
 	return 1;
 }
 

--- a/src/lua/functions/creatures/combat/combat_functions.cpp
+++ b/src/lua/functions/creatures/combat/combat_functions.cpp
@@ -27,7 +27,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void CombatFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Combat", "", CombatFunctions::luaCombatCreate);
+	Lua::registerSharedClass<Combat>(L, "", CombatFunctions::luaCombatCreate);
 	Lua::registerMetaMethod(L, "Combat", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Combat", "setParameter", CombatFunctions::luaCombatSetParameter);
@@ -48,8 +48,7 @@ void CombatFunctions::init(lua_State* L) {
 int CombatFunctions::luaCombatCreate(lua_State* L) {
 	// Combat()
 	auto combat = std::make_shared<Combat>();
-	Lua::pushUserdata<Combat>(L, combat);
-	Lua::setMetatable(L, -1, "Combat");
+	Lua::pushSharedUserdata<Combat>(L, combat);
 	return 1;
 }
 
@@ -120,7 +119,7 @@ int CombatFunctions::luaCombatSetArea(lua_State* L) {
 int CombatFunctions::luaCombatSetCondition(lua_State* L) {
 	// combat:addCondition(condition)
 	const std::shared_ptr<Condition> &condition = Lua::getUserdataShared<Condition>(L, 2);
-	auto* combat = Lua::getUserdata<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
 	if (combat && condition) {
 		combat->addCondition(condition->clone());
 		Lua::pushBoolean(L, true);

--- a/src/lua/functions/creatures/combat/condition_functions.cpp
+++ b/src/lua/functions/creatures/combat/condition_functions.cpp
@@ -26,10 +26,9 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ConditionFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Condition", "", ConditionFunctions::luaConditionCreate);
+	Lua::registerSharedClass<Condition>(L, "", ConditionFunctions::luaConditionCreate);
 	Lua::registerMetaMethod(L, "Condition", "__eq", Lua::luaUserdataCompare);
-	Lua::registerMetaMethod(L, "Condition", "__gc", ConditionFunctions::luaConditionDelete);
-	Lua::registerMethod(L, "Condition", "delete", ConditionFunctions::luaConditionDelete);
+	Lua::registerMethod(L, "Condition", "delete", Lua::luaSharedPtrGarbageCollection<Condition>);
 
 	Lua::registerMethod(L, "Condition", "getId", ConditionFunctions::luaConditionGetId);
 	Lua::registerMethod(L, "Condition", "getSubId", ConditionFunctions::luaConditionGetSubId);
@@ -64,21 +63,11 @@ int ConditionFunctions::luaConditionCreate(lua_State* L) {
 
 	const auto &condition = Condition::createCondition(conditionId, conditionType, 0, 0, false, subId, isPersistent);
 	if (condition) {
-		Lua::pushUserdata<Condition>(L, condition);
-		Lua::setMetatable(L, -1, "Condition");
+		Lua::pushSharedUserdata<Condition>(L, condition);
 	} else {
 		lua_pushnil(L);
 	}
 	return 1;
-}
-
-int ConditionFunctions::luaConditionDelete(lua_State* L) {
-	// condition:delete()
-	std::shared_ptr<Condition>* conditionPtr = Lua::getRawUserDataShared<Condition>(L, 1);
-	if (conditionPtr && *conditionPtr) {
-		conditionPtr->reset();
-	}
-	return 0;
 }
 
 int ConditionFunctions::luaConditionGetId(lua_State* L) {
@@ -162,8 +151,7 @@ int ConditionFunctions::luaConditionClone(lua_State* L) {
 	// condition:clone()
 	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
 	if (condition) {
-		Lua::pushUserdata<Condition>(L, condition->clone());
-		Lua::setMetatable(L, -1, "Condition");
+		Lua::pushSharedUserdata<Condition>(L, condition->clone());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/combat/condition_functions.hpp
+++ b/src/lua/functions/creatures/combat/condition_functions.hpp
@@ -23,7 +23,6 @@ public:
 
 private:
 	static int luaConditionCreate(lua_State* L);
-	static int luaConditionDelete(lua_State* L);
 
 	static int luaConditionGetId(lua_State* L);
 	static int luaConditionGetSubId(lua_State* L);

--- a/src/lua/functions/creatures/combat/spell_functions.cpp
+++ b/src/lua/functions/creatures/combat/spell_functions.cpp
@@ -24,7 +24,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void SpellFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Spell", "", SpellFunctions::luaSpellCreate);
+	Lua::registerSharedClass<Spell>(L, "", SpellFunctions::luaSpellCreate);
 	Lua::registerMetaMethod(L, "Spell", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Spell", "onCastSpell", SpellFunctions::luaSpellOnCastSpell);
@@ -91,8 +91,7 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 		const auto &rune = g_spells().getRuneSpell(id);
 
 		if (rune) {
-			Lua::pushUserdata<Spell>(L, rune);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, rune);
 			return 1;
 		}
 
@@ -101,20 +100,17 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 		const std::string arg = Lua::getString(L, 2);
 		auto instant = g_spells().getInstantSpellByName(arg);
 		if (instant) {
-			Lua::pushUserdata<Spell>(L, instant);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, instant);
 			return 1;
 		}
 		instant = g_spells().getInstantSpell(arg);
 		if (instant) {
-			Lua::pushUserdata<Spell>(L, instant);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, instant);
 			return 1;
 		}
 		const auto &rune = g_spells().getRuneSpellByName(arg);
 		if (rune) {
-			Lua::pushUserdata<Spell>(L, rune);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, rune);
 			return 1;
 		}
 
@@ -128,14 +124,12 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 
 	if (spellType == SPELL_INSTANT) {
 		const auto &spell = std::make_shared<InstantSpell>();
-		Lua::pushUserdata<Spell>(L, spell);
-		Lua::setMetatable(L, -1, "Spell");
+		Lua::pushSharedUserdata<Spell>(L, spell);
 		spell->spellType = SPELL_INSTANT;
 		return 1;
 	} else if (spellType == SPELL_RUNE) {
 		const auto &runeSpell = std::make_shared<RuneSpell>();
-		Lua::pushUserdata<Spell>(L, runeSpell);
-		Lua::setMetatable(L, -1, "Spell");
+		Lua::pushSharedUserdata<Spell>(L, runeSpell);
 		runeSpell->spellType = SPELL_RUNE;
 		return 1;
 	}

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -766,8 +766,7 @@ int CreatureFunctions::luaCreatureGetCondition(lua_State* L) {
 
 	const auto &condition = creature->getCondition(conditionType, conditionId, subId);
 	if (condition) {
-		Lua::pushUserdata<const Condition>(L, condition);
-		Lua::setWeakMetatable(L, -1, "Condition");
+		Lua::pushSharedUserdata<Condition>(L, condition);
 	} else {
 		lua_pushnil(L);
 	}
@@ -1099,8 +1098,7 @@ int CreatureFunctions::luaCreatureGetZones(lua_State* L) {
 	int index = 0;
 	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;

--- a/src/lua/functions/creatures/monster/charm_functions.cpp
+++ b/src/lua/functions/creatures/monster/charm_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void CharmFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Charm", "", CharmFunctions::luaCharmCreate);
+	Lua::registerSharedClass<Charm>(L, "", CharmFunctions::luaCharmCreate);
 	Lua::registerMetaMethod(L, "Charm", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Charm", "name", CharmFunctions::luaCharmName);
@@ -47,8 +47,7 @@ int CharmFunctions::luaCharmCreate(lua_State* L) {
 		const auto charmList = g_game().getCharmList();
 		for (const auto &charm : charmList) {
 			if (charm->id == charmid) {
-				Lua::pushUserdata<Charm>(L, charm);
-				Lua::setMetatable(L, -1, "Charm");
+				Lua::pushSharedUserdata<Charm>(L, charm);
 				Lua::pushBoolean(L, true);
 			}
 		}

--- a/src/lua/functions/creatures/monster/loot_functions.cpp
+++ b/src/lua/functions/creatures/monster/loot_functions.cpp
@@ -23,7 +23,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void LootFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Loot", "", LootFunctions::luaCreateLoot);
+	Lua::registerSharedClass<Loot>(L, "", LootFunctions::luaCreateLoot);
 
 	Lua::registerMethod(L, "Loot", "setId", LootFunctions::luaLootSetId);
 	Lua::registerMethod(L, "Loot", "setIdFromName", LootFunctions::luaLootSetIdFromName);
@@ -48,8 +48,7 @@ void LootFunctions::init(lua_State* L) {
 int LootFunctions::luaCreateLoot(lua_State* L) {
 	// Loot() will create a new loot item
 	auto loot = std::make_shared<Loot>();
-	Lua::pushUserdata<Loot>(L, loot);
-	Lua::setMetatable(L, -1, "Loot");
+	Lua::pushSharedUserdata<Loot>(L, loot);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -131,8 +131,7 @@ int MonsterFunctions::luaMonsterGetType(lua_State* L) {
 	// monster:getType()
 	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
 	if (monster) {
-		Lua::pushUserdata<MonsterType>(L, monster->mType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monster->mType);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/monster/monster_spell_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_spell_functions.cpp
@@ -21,7 +21,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void MonsterSpellFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "MonsterSpell", "", MonsterSpellFunctions::luaCreateMonsterSpell);
+	Lua::registerSharedClass<MonsterSpell>(L, "", MonsterSpellFunctions::luaCreateMonsterSpell);
 
 	Lua::registerMethod(L, "MonsterSpell", "setType", MonsterSpellFunctions::luaMonsterSpellSetType);
 	Lua::registerMethod(L, "MonsterSpell", "setScriptName", MonsterSpellFunctions::luaMonsterSpellSetScriptName);
@@ -50,8 +50,7 @@ void MonsterSpellFunctions::init(lua_State* L) {
 
 int MonsterSpellFunctions::luaCreateMonsterSpell(lua_State* L) {
 	const auto spell = std::make_shared<MonsterSpell>();
-	Lua::pushUserdata<MonsterSpell>(L, spell);
-	Lua::setMetatable(L, -1, "MonsterSpell");
+	Lua::pushSharedUserdata<MonsterSpell>(L, spell);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -29,7 +29,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void MonsterTypeFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "MonsterType", "", MonsterTypeFunctions::luaMonsterTypeCreate);
+	Lua::registerSharedClass<MonsterType>(L, "", MonsterTypeFunctions::luaMonsterTypeCreate);
 	Lua::registerMetaMethod(L, "MonsterType", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "MonsterType", "isAttackable", MonsterTypeFunctions::luaMonsterTypeIsAttackable);
@@ -203,8 +203,7 @@ int MonsterTypeFunctions::luaMonsterTypeCreate(lua_State* L) {
 	}
 
 	if (monsterType) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -1938,8 +1937,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetMonstersByRace(lua_State* L) {
 	lua_createtable(L, monstersByRace.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByRace) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -1952,8 +1950,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetMonstersByBestiaryStars(lua_State* L)
 	lua_createtable(L, monstersByStars.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByStars) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;

--- a/src/lua/functions/creatures/npc/shop_functions.cpp
+++ b/src/lua/functions/creatures/npc/shop_functions.cpp
@@ -24,7 +24,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ShopFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Shop", "", ShopFunctions::luaCreateShop);
+	Lua::registerSharedClass<Shop>(L, "", ShopFunctions::luaCreateShop);
 	Lua::registerMethod(L, "Shop", "setId", ShopFunctions::luaShopSetId);
 	Lua::registerMethod(L, "Shop", "setIdFromName", ShopFunctions::luaShopSetIdFromName);
 	Lua::registerMethod(L, "Shop", "setNameItem", ShopFunctions::luaShopSetNameItem);
@@ -38,8 +38,7 @@ void ShopFunctions::init(lua_State* L) {
 
 int ShopFunctions::luaCreateShop(lua_State* L) {
 	// Shop() will create a new shop item
-	Lua::pushUserdata<Shop>(L, std::make_shared<Shop>());
-	Lua::setMetatable(L, -1, "Shop");
+	Lua::pushSharedUserdata<Shop>(L, std::make_shared<Shop>());
 	return 1;
 }
 

--- a/src/lua/functions/creatures/player/group_functions.cpp
+++ b/src/lua/functions/creatures/player/group_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void GroupFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Group", "", GroupFunctions::luaGroupCreate);
+	Lua::registerSharedClass<Group>(L, "", GroupFunctions::luaGroupCreate);
 	Lua::registerMetaMethod(L, "Group", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Group", "getId", GroupFunctions::luaGroupGetId);
@@ -40,8 +40,7 @@ int GroupFunctions::luaGroupCreate(lua_State* L) {
 
 	const auto &group = g_game().groups.getGroup(id);
 	if (group) {
-		Lua::pushUserdata<Group>(L, group);
-		Lua::setMetatable(L, -1, "Group");
+		Lua::pushSharedUserdata<Group>(L, group);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/guild_functions.cpp
+++ b/src/lua/functions/creatures/player/guild_functions.cpp
@@ -23,7 +23,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void GuildFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Guild", "", GuildFunctions::luaGuildCreate);
+	Lua::registerSharedClass<Guild>(L, "", GuildFunctions::luaGuildCreate);
 	Lua::registerMetaMethod(L, "Guild", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Guild", "getId", GuildFunctions::luaGuildGetId);
@@ -42,8 +42,7 @@ int GuildFunctions::luaGuildCreate(lua_State* L) {
 	const uint32_t id = Lua::getNumber<uint32_t>(L, 2);
 	const auto &guild = g_game().getGuild(id);
 	if (guild) {
-		Lua::pushUserdata<Guild>(L, guild);
-		Lua::setMetatable(L, -1, "Guild");
+		Lua::pushSharedUserdata<Guild>(L, guild);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/mount_functions.cpp
+++ b/src/lua/functions/creatures/player/mount_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void MountFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Mount", "", MountFunctions::luaCreateMount);
+	Lua::registerSharedClass<Mount>(L, "", MountFunctions::luaCreateMount);
 	Lua::registerMetaMethod(L, "Mount", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Mount", "getName", MountFunctions::luaMountGetName);
@@ -44,8 +44,7 @@ int MountFunctions::luaCreateMount(lua_State* L) {
 	}
 
 	if (mount) {
-		Lua::pushUserdata<Mount>(L, mount);
-		Lua::setMetatable(L, -1, "Mount");
+		Lua::pushSharedUserdata<Mount>(L, mount);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -976,8 +976,7 @@ int PlayerFunctions::luaPlayergetCharmMonsterType(lua_State* L) {
 		if (raceid > 0) {
 			const auto &mtype = g_monsters().getMonsterTypeByRaceId(raceid);
 			if (mtype) {
-				Lua::pushUserdata<MonsterType>(L, mtype);
-				Lua::setMetatable(L, -1, "MonsterType");
+				Lua::pushSharedUserdata<MonsterType>(L, mtype);
 			} else {
 				lua_pushnil(L);
 			}
@@ -2174,8 +2173,7 @@ int PlayerFunctions::luaPlayerGetVocation(lua_State* L) {
 	// player:getVocation()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1);
 	if (player) {
-		Lua::pushUserdata<Vocation>(L, player->getVocation());
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, player->getVocation());
 	} else {
 		lua_pushnil(L);
 	}
@@ -2279,8 +2277,7 @@ int PlayerFunctions::luaPlayerGetTown(lua_State* L) {
 	// player:getTown()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1);
 	if (player) {
-		Lua::pushUserdata<Town>(L, player->getTown());
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, player->getTown());
 	} else {
 		lua_pushnil(L);
 	}
@@ -2319,8 +2316,7 @@ int PlayerFunctions::luaPlayerGetGuild(lua_State* L) {
 		return 1;
 	}
 
-	Lua::pushUserdata<Guild>(L, guild);
-	Lua::setMetatable(L, -1, "Guild");
+	Lua::pushSharedUserdata<Guild>(L, guild);
 	return 1;
 }
 
@@ -2398,8 +2394,7 @@ int PlayerFunctions::luaPlayerGetGroup(lua_State* L) {
 	// player:getGroup()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1);
 	if (player) {
-		Lua::pushUserdata<Group>(L, player->getGroup());
-		Lua::setMetatable(L, -1, "Group");
+		Lua::pushSharedUserdata<Group>(L, player->getGroup());
 	} else {
 		lua_pushnil(L);
 	}
@@ -5171,8 +5166,7 @@ int PlayerFunctions::luaPlayerKV(lua_State* L) {
 		return 1;
 	}
 
-	Lua::pushUserdata<KV>(L, player->kv());
-	Lua::setMetatable(L, -1, "KV");
+	Lua::pushSharedUserdata<KV>(L, player->kv());
 	return 1;
 }
 

--- a/src/lua/functions/creatures/player/vocation_functions.cpp
+++ b/src/lua/functions/creatures/player/vocation_functions.cpp
@@ -21,7 +21,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void VocationFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Vocation", "", VocationFunctions::luaVocationCreate);
+	Lua::registerSharedClass<Vocation>(L, "", VocationFunctions::luaVocationCreate);
 	Lua::registerMetaMethod(L, "Vocation", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Vocation", "getId", VocationFunctions::luaVocationGetId);
@@ -68,8 +68,7 @@ int VocationFunctions::luaVocationCreate(lua_State* L) {
 
 	const auto &vocation = g_vocations().getVocation(vocationId);
 	if (vocation) {
-		Lua::pushUserdata<Vocation>(L, vocation);
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, vocation);
 	} else {
 		lua_pushnil(L);
 	}
@@ -304,8 +303,7 @@ int VocationFunctions::luaVocationGetDemotion(lua_State* L) {
 
 	const auto &demotedVocation = g_vocations().getVocation(fromId);
 	if (demotedVocation && demotedVocation != vocation) {
-		Lua::pushUserdata<Vocation>(L, demotedVocation);
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, demotedVocation);
 	} else {
 		lua_pushnil(L);
 	}
@@ -328,8 +326,7 @@ int VocationFunctions::luaVocationGetPromotion(lua_State* L) {
 
 	const auto &promotedVocation = g_vocations().getVocation(promotedId);
 	if (promotedVocation && promotedVocation != vocation) {
-		Lua::pushUserdata<Vocation>(L, promotedVocation);
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, promotedVocation);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/events/action_functions.cpp
+++ b/src/lua/functions/events/action_functions.cpp
@@ -23,7 +23,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ActionFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Action", "", ActionFunctions::luaCreateAction);
+	Lua::registerSharedClass<Action>(L, "", ActionFunctions::luaCreateAction);
 	Lua::registerMethod(L, "Action", "onUse", ActionFunctions::luaActionOnUse);
 	Lua::registerMethod(L, "Action", "register", ActionFunctions::luaActionRegister);
 	Lua::registerMethod(L, "Action", "id", ActionFunctions::luaActionItemId);
@@ -39,8 +39,7 @@ void ActionFunctions::init(lua_State* L) {
 int ActionFunctions::luaCreateAction(lua_State* L) {
 	// Action()
 	const auto action = std::make_shared<Action>();
-	Lua::pushUserdata<Action>(L, action);
-	Lua::setMetatable(L, -1, "Action");
+	Lua::pushSharedUserdata<Action>(L, action);
 	return 1;
 }
 

--- a/src/lua/functions/events/creature_event_functions.cpp
+++ b/src/lua/functions/events/creature_event_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void CreatureEventFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "CreatureEvent", "", CreatureEventFunctions::luaCreateCreatureEvent);
+	Lua::registerSharedClass<CreatureEvent>(L, "", CreatureEventFunctions::luaCreateCreatureEvent);
 	Lua::registerMethod(L, "CreatureEvent", "type", CreatureEventFunctions::luaCreatureEventType);
 	Lua::registerMethod(L, "CreatureEvent", "register", CreatureEventFunctions::luaCreatureEventRegister);
 	Lua::registerMethod(L, "CreatureEvent", "onLogin", CreatureEventFunctions::luaCreatureEventOnCallback);
@@ -43,8 +43,7 @@ int CreatureEventFunctions::luaCreateCreatureEvent(lua_State* L) {
 	// CreatureEvent(eventName)
 	const auto creatureEvent = std::make_shared<CreatureEvent>();
 	creatureEvent->setName(Lua::getString(L, 2));
-	Lua::pushUserdata<CreatureEvent>(L, creatureEvent);
-	Lua::setMetatable(L, -1, "CreatureEvent");
+	Lua::pushSharedUserdata<CreatureEvent>(L, creatureEvent);
 	return 1;
 }
 

--- a/src/lua/functions/events/event_callback_functions.cpp
+++ b/src/lua/functions/events/event_callback_functions.cpp
@@ -35,7 +35,7 @@
  */
 
 void EventCallbackFunctions::init(lua_State* luaState) {
-	Lua::registerSharedClass(luaState, "EventCallback", "", EventCallbackFunctions::luaEventCallbackCreate);
+	Lua::registerSharedClass<EventCallback>(luaState, "", EventCallbackFunctions::luaEventCallbackCreate);
 	Lua::registerMethod(luaState, "EventCallback", "type", EventCallbackFunctions::luaEventCallbackType);
 	Lua::registerMethod(luaState, "EventCallback", "register", EventCallbackFunctions::luaEventCallbackRegister);
 }
@@ -49,8 +49,7 @@ int EventCallbackFunctions::luaEventCallbackCreate(lua_State* luaState) {
 
 	bool skipDuplicationCheck = Lua::getBoolean(luaState, 3, false);
 	const auto eventCallback = std::make_shared<EventCallback>(callbackName, skipDuplicationCheck);
-	Lua::pushUserdata<EventCallback>(luaState, eventCallback);
-	Lua::setMetatable(luaState, -1, "EventCallback");
+	Lua::pushSharedUserdata<EventCallback>(luaState, eventCallback);
 	return 1;
 }
 

--- a/src/lua/functions/events/global_event_functions.cpp
+++ b/src/lua/functions/events/global_event_functions.cpp
@@ -23,7 +23,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void GlobalEventFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "GlobalEvent", "", GlobalEventFunctions::luaCreateGlobalEvent);
+	Lua::registerSharedClass<GlobalEvent>(L, "", GlobalEventFunctions::luaCreateGlobalEvent);
 	Lua::registerMethod(L, "GlobalEvent", "type", GlobalEventFunctions::luaGlobalEventType);
 	Lua::registerMethod(L, "GlobalEvent", "register", GlobalEventFunctions::luaGlobalEventRegister);
 	Lua::registerMethod(L, "GlobalEvent", "time", GlobalEventFunctions::luaGlobalEventTime);
@@ -41,8 +41,7 @@ int GlobalEventFunctions::luaCreateGlobalEvent(lua_State* L) {
 	const auto global = std::make_shared<GlobalEvent>();
 	global->setName(Lua::getString(L, 2));
 	global->setEventType(GLOBALEVENT_NONE);
-	Lua::pushUserdata<GlobalEvent>(L, global);
-	Lua::setMetatable(L, -1, "GlobalEvent");
+	Lua::pushSharedUserdata<GlobalEvent>(L, global);
 	return 1;
 }
 

--- a/src/lua/functions/events/talk_action_functions.cpp
+++ b/src/lua/functions/events/talk_action_functions.cpp
@@ -26,7 +26,7 @@
 #include "lua/scripts/luascript.hpp"
 
 void TalkActionFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "TalkAction", "", TalkActionFunctions::luaCreateTalkAction);
+	Lua::registerSharedClass<TalkAction>(L, "", TalkActionFunctions::luaCreateTalkAction);
 	Lua::registerMethod(L, "TalkAction", "onSay", TalkActionFunctions::luaTalkActionOnSay);
 	Lua::registerMethod(L, "TalkAction", "groupType", TalkActionFunctions::luaTalkActionGroupType);
 	Lua::registerMethod(L, "TalkAction", "register", TalkActionFunctions::luaTalkActionRegister);
@@ -47,8 +47,7 @@ int TalkActionFunctions::luaCreateTalkAction(lua_State* L) {
 
 	const auto talkactionSharedPtr = std::make_shared<TalkAction>();
 	talkactionSharedPtr->setWords(wordsVector);
-	Lua::pushUserdata<TalkAction>(L, talkactionSharedPtr);
-	Lua::setMetatable(L, -1, "TalkAction");
+	Lua::pushSharedUserdata<TalkAction>(L, talkactionSharedPtr);
 	return 1;
 }
 

--- a/src/lua/functions/items/weapon_functions.cpp
+++ b/src/lua/functions/items/weapon_functions.cpp
@@ -24,7 +24,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void WeaponFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Weapon", "", WeaponFunctions::luaCreateWeapon);
+	Lua::registerSharedClass<Weapon>(L, "", WeaponFunctions::luaCreateWeapon);
 	Lua::registerMethod(L, "Weapon", "action", WeaponFunctions::luaWeaponAction);
 	Lua::registerMethod(L, "Weapon", "register", WeaponFunctions::luaWeaponRegister);
 	Lua::registerMethod(L, "Weapon", "id", WeaponFunctions::luaWeaponId);
@@ -73,8 +73,7 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 		case WEAPON_AXE:
 		case WEAPON_CLUB: {
 			auto weaponPtr = std::make_shared<WeaponMelee>();
-			Lua::pushUserdata<WeaponMelee>(L, weaponPtr);
-			Lua::setMetatable(L, -1, "Weapon");
+			Lua::pushSharedUserdata<Weapon>(L, weaponPtr);
 			weaponPtr->weaponType = type;
 			break;
 		}
@@ -82,15 +81,13 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 		case WEAPON_DISTANCE:
 		case WEAPON_AMMO: {
 			auto weaponPtr = std::make_shared<WeaponDistance>();
-			Lua::pushUserdata<WeaponDistance>(L, weaponPtr);
-			Lua::setMetatable(L, -1, "Weapon");
+			Lua::pushSharedUserdata<Weapon>(L, weaponPtr);
 			weaponPtr->weaponType = type;
 			break;
 		}
 		case WEAPON_WAND: {
 			auto weaponPtr = std::make_shared<WeaponWand>();
-			Lua::pushUserdata<WeaponWand>(L, weaponPtr);
-			Lua::setMetatable(L, -1, "Weapon");
+			Lua::pushSharedUserdata<Weapon>(L, weaponPtr);
 			weaponPtr->weaponType = type;
 			break;
 		}
@@ -129,15 +126,19 @@ int WeaponFunctions::luaWeaponAction(lua_State* L) {
 
 int WeaponFunctions::luaWeaponRegister(lua_State* L) {
 	// weapon:register()
-	const WeaponShared_ptr* weaponPtr = Lua::getRawUserDataShared<Weapon>(L, 1);
-	if (weaponPtr && *weaponPtr) {
-		WeaponShared_ptr weapon = *weaponPtr;
+	WeaponShared_ptr weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	if (weapon) {
 		if (weapon->weaponType == WEAPON_DISTANCE || weapon->weaponType == WEAPON_AMMO || weapon->weaponType == WEAPON_MISSILE) {
-			weapon = Lua::getUserdataShared<WeaponDistance>(L, 1);
+			weapon = std::dynamic_pointer_cast<WeaponDistance>(weapon);
 		} else if (weapon->weaponType == WEAPON_WAND) {
-			weapon = Lua::getUserdataShared<WeaponWand>(L, 1);
+			weapon = std::dynamic_pointer_cast<WeaponWand>(weapon);
 		} else {
-			weapon = Lua::getUserdataShared<WeaponMelee>(L, 1);
+			weapon = std::dynamic_pointer_cast<WeaponMelee>(weapon);
+		}
+
+		if (!weapon) {
+			lua_pushnil(L);
+			return 1;
 		}
 
 		const uint16_t id = weapon->getID();
@@ -288,7 +289,7 @@ int WeaponFunctions::luaWeaponBreakChance(lua_State* L) {
 
 int WeaponFunctions::luaWeaponWandDamage(lua_State* L) {
 	// weapon:damage(damage[min, max]) only use this if the weapon is a wand!
-	const auto &weapon = Lua::getUserdataShared<WeaponWand>(L, 1);
+	const auto weapon = std::dynamic_pointer_cast<WeaponWand>(Lua::getUserdataShared<Weapon>(L, 1));
 	if (weapon) {
 		weapon->setMinChange(Lua::getNumber<uint32_t>(L, 2));
 		if (lua_gettop(L) > 2) {
@@ -566,7 +567,7 @@ int WeaponFunctions::luaWeaponSlotType(lua_State* L) {
 
 int WeaponFunctions::luaWeaponAmmoType(lua_State* L) {
 	// weapon:ammoType(type)
-	const auto &weapon = Lua::getUserdataShared<WeaponDistance>(L, 1);
+	const auto weapon = std::dynamic_pointer_cast<WeaponDistance>(Lua::getUserdataShared<Weapon>(L, 1));
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -22,7 +22,14 @@
 #include "game/movement/position.hpp"
 #include "lua/scripts/script_environment.hpp"
 
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <memory>
+	#include <string_view>
+	#include <type_traits>
+#endif
+
 class Combat;
+class Condition;
 class Creature;
 class Cylinder;
 class Game;
@@ -33,10 +40,146 @@ class Thing;
 class Guild;
 class Zone;
 class KV;
+class NetworkMessage;
+class Action;
+class TalkAction;
+class CreatureEvent;
+class GlobalEvent;
+class EventCallback;
+class Town;
+class Vocation;
+class Shop;
+class Loot;
+class MonsterSpell;
+class MonsterType;
+class Weapon;
+class Spell;
+class Charm;
+struct ModalWindow;
+struct Group;
+struct Mount;
 
 using lua_Number = double;
 
 struct LuaVariant;
+
+template <typename T>
+struct LuaUserdataTraits;
+
+template <>
+struct LuaUserdataTraits<KV> {
+	static constexpr std::string_view name = "KV";
+};
+
+template <>
+struct LuaUserdataTraits<NetworkMessage> {
+	static constexpr std::string_view name = "NetworkMessage";
+};
+
+template <>
+struct LuaUserdataTraits<Condition> {
+	static constexpr std::string_view name = "Condition";
+};
+
+template <>
+struct LuaUserdataTraits<Action> {
+	static constexpr std::string_view name = "Action";
+};
+
+template <>
+struct LuaUserdataTraits<Charm> {
+	static constexpr std::string_view name = "Charm";
+};
+
+template <>
+struct LuaUserdataTraits<Combat> {
+	static constexpr std::string_view name = "Combat";
+};
+
+template <>
+struct LuaUserdataTraits<CreatureEvent> {
+	static constexpr std::string_view name = "CreatureEvent";
+};
+
+template <>
+struct LuaUserdataTraits<EventCallback> {
+	static constexpr std::string_view name = "EventCallback";
+};
+
+template <>
+struct LuaUserdataTraits<GlobalEvent> {
+	static constexpr std::string_view name = "GlobalEvent";
+};
+
+template <>
+struct LuaUserdataTraits<Group> {
+	static constexpr std::string_view name = "Group";
+};
+
+template <>
+struct LuaUserdataTraits<Guild> {
+	static constexpr std::string_view name = "Guild";
+};
+
+template <>
+struct LuaUserdataTraits<Loot> {
+	static constexpr std::string_view name = "Loot";
+};
+
+template <>
+struct LuaUserdataTraits<ModalWindow> {
+	static constexpr std::string_view name = "ModalWindow";
+};
+
+template <>
+struct LuaUserdataTraits<MonsterSpell> {
+	static constexpr std::string_view name = "MonsterSpell";
+};
+
+template <>
+struct LuaUserdataTraits<MonsterType> {
+	static constexpr std::string_view name = "MonsterType";
+};
+
+template <>
+struct LuaUserdataTraits<Mount> {
+	static constexpr std::string_view name = "Mount";
+};
+
+template <>
+struct LuaUserdataTraits<Shop> {
+	static constexpr std::string_view name = "Shop";
+};
+
+template <>
+struct LuaUserdataTraits<Spell> {
+	static constexpr std::string_view name = "Spell";
+};
+
+template <>
+struct LuaUserdataTraits<TalkAction> {
+	static constexpr std::string_view name = "TalkAction";
+};
+
+template <>
+struct LuaUserdataTraits<Town> {
+	static constexpr std::string_view name = "Town";
+};
+
+template <>
+struct LuaUserdataTraits<Vocation> {
+	static constexpr std::string_view name = "Vocation";
+};
+
+template <>
+struct LuaUserdataTraits<Weapon> {
+	static constexpr std::string_view name = "Weapon";
+};
+
+template <>
+struct LuaUserdataTraits<Zone> {
+	static constexpr std::string_view name = "Zone";
+};
 
 #define reportErrorFunc(a) reportError(__FUNCTION__, a, true)
 
@@ -238,7 +381,61 @@ public:
 	}
 
 	template <class T>
-	static void pushUserdata(lua_State* L, std::shared_ptr<T> value) {
+	static constexpr std::string_view getUserdataMetatableName() {
+		using RawT = std::remove_cv_t<T>;
+		static_assert(
+			requires { LuaUserdataTraits<RawT>::name; }, "LuaUserdataTraits<T>::name must be defined for shared userdata"
+		);
+		return LuaUserdataTraits<RawT>::name;
+	}
+
+	template <class T>
+	static int luaSharedPtrGarbageCollection(lua_State* L) {
+		const std::string metatableName(getUserdataMetatableName<T>());
+		auto objPtr = static_cast<std::shared_ptr<T>*>(luaL_testudata(L, 1, metatableName.c_str()));
+		if (!objPtr) {
+			// Subtypes (e.g. Weapon variants) are pushed under the base metatable; the __gc is
+			// bound to this metatable so the raw userdata still stores a std::shared_ptr<T>.
+			objPtr = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+		}
+		if (!objPtr) {
+			return 0;
+		}
+
+		std::destroy_at(objPtr);
+		std::construct_at(objPtr);
+		return 0;
+	}
+
+	template <class T>
+	static void registerSharedClass(lua_State* L, const std::string &baseClass, lua_CFunction newFunction = nullptr) {
+		if (!baseClass.empty()) {
+			luaL_error(L, "typed shared userdata does not support baseClass inheritance");
+			return;
+		}
+
+		const std::string className(getUserdataMetatableName<T>());
+		registerClass(L, className, baseClass, newFunction);
+		registerMetaMethod(L, className, "__gc", luaSharedPtrGarbageCollection<T>);
+	}
+
+	template <class T>
+	static void pushSharedUserdata(lua_State* L, std::shared_ptr<T> value) {
+		static_assert(!std::is_const_v<T>, "pushSharedUserdata<T> requires a non-const shared_ptr type");
+		auto userData = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
+		new (userData) std::shared_ptr<T>(std::move(value));
+		setMetatable(L, -1, std::string(getUserdataMetatableName<T>()));
+	}
+
+	template <class T>
+	static void pushBorrowedSharedUserdata(lua_State* L, T &value) {
+		static_assert(!std::is_const_v<T>, "pushBorrowedSharedUserdata<T> requires a non-const borrowed type");
+		// This only prevents invalid delete and releases the control block; callers must not keep it past the callback.
+		pushSharedUserdata<T>(L, std::shared_ptr<T>(&value, [](T*) { }));
+	}
+
+	template <class T>
+	[[deprecated("use pushSharedUserdata<T> or pushBorrowedSharedUserdata<T>")]] static void pushUserdata(lua_State* L, std::shared_ptr<T> value) {
 		// This is basically malloc from C++ point of view.
 		auto userData = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
 		// Copy constructor, bumps ref count.
@@ -246,7 +443,7 @@ public:
 	}
 
 	static void registerClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
-	static void registerSharedClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
+	[[deprecated("use registerSharedClass<T> with LuaUserdataTraits<T>")]] static void registerSharedClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
 	static void registerMethod(lua_State* L, const std::string &globalName, const std::string &methodName, lua_CFunction func);
 	static void registerMetaMethod(lua_State* L, const std::string &className, const std::string &methodName, lua_CFunction func);
 	static void registerTable(lua_State* L, const std::string &tableName);

--- a/src/lua/functions/map/house_functions.cpp
+++ b/src/lua/functions/map/house_functions.cpp
@@ -109,8 +109,7 @@ int HouseFunctions::luaHouseGetTown(lua_State* L) {
 	}
 
 	if (const auto &town = g_game().map.towns.getTown(house->getTownId())) {
-		Lua::pushUserdata<Town>(L, town);
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, town);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/map/position_functions.cpp
+++ b/src/lua/functions/map/position_functions.cpp
@@ -169,11 +169,13 @@ int PositionFunctions::luaPositionGetZones(lua_State* L) {
 		lua_pushnil(L);
 		return 1;
 	}
+	const auto &zones = tile->getZones();
+	lua_createtable(L, static_cast<int>(zones.size()), 0);
+
 	int index = 0;
-	for (const auto &zone : tile->getZones()) {
+	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;

--- a/src/lua/functions/map/town_functions.cpp
+++ b/src/lua/functions/map/town_functions.cpp
@@ -22,7 +22,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void TownFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Town", "", TownFunctions::luaTownCreate);
+	Lua::registerSharedClass<Town>(L, "", TownFunctions::luaTownCreate);
 	Lua::registerMetaMethod(L, "Town", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Town", "getId", TownFunctions::luaTownGetId);
@@ -42,8 +42,7 @@ int TownFunctions::luaTownCreate(lua_State* L) {
 	}
 
 	if (town) {
-		Lua::pushUserdata<Town>(L, town);
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, town);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/modules/modules.cpp
+++ b/src/lua/modules/modules.cpp
@@ -181,8 +181,7 @@ void Module::executeOnRecvbyte(const std::shared_ptr<Player> &player, NetworkMes
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<NetworkMessage>(L, std::shared_ptr<NetworkMessage>(&msg));
-	LuaScriptInterface::setWeakMetatable(L, -1, "NetworkMessage");
+	LuaScriptInterface::pushBorrowedSharedUserdata<NetworkMessage>(L, msg);
 
 	lua_pushnumber(L, recvbyte);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -375,13 +375,19 @@ void Map::moveCreature(const std::shared_ptr<Creature> &creature, const std::sha
 		spectators.find<Creature>(newPos, true, 0, 0, 0, 0, false);
 	}
 
-	const auto playersSpectators = spectators.filter<Player>();
+	std::vector<Player*> playerSpectators;
+	playerSpectators.reserve(spectators.size());
+	for (const auto &spectator : spectators) {
+		if (auto* player = spectator->getPlayerRaw()) {
+			playerSpectators.emplace_back(player);
+		}
+	}
 
 	std::vector<int32_t> oldStackPosVector;
-	oldStackPosVector.reserve(playersSpectators.size());
-	for (const auto &spec : playersSpectators) {
-		if (spec->canSeeCreature(creature)) {
-			oldStackPosVector.push_back(oldTile->getClientIndexOfCreature(spec->getPlayer(), creature));
+	oldStackPosVector.reserve(playerSpectators.size());
+	for (const auto* player : playerSpectators) {
+		if (player->canSeeCreature(creature)) {
+			oldStackPosVector.push_back(oldTile->getClientIndexOfCreature(player, creature));
 		} else {
 			oldStackPosVector.push_back(-1);
 		}
@@ -418,11 +424,10 @@ void Map::moveCreature(const std::shared_ptr<Creature> &creature, const std::sha
 
 	// send to client
 	size_t i = 0;
-	for (const auto &spectator : playersSpectators) {
+	for (const auto* player : playerSpectators) {
 		// Use the correct stackpos
 		const int32_t stackpos = oldStackPosVector[i++];
 		if (stackpos != -1) {
-			const auto &player = spectator->getPlayer();
 			player->sendCreatureMove(creature, newPos, newTile->getStackposOfCreature(player, creature), oldPos, stackpos, teleport);
 		}
 	}

--- a/src/map/spectators.cpp
+++ b/src/map/spectators.cpp
@@ -81,7 +81,7 @@ bool Spectators::checkCache(const SpectatorsCache::FloorData &specData, bool onl
 
 			// Check type if needed
 			if (needsTypeCheck) {
-				if ((onlyPlayers && !creature->getPlayer()) || (onlyMonsters && !creature->getMonster()) || (onlyNpcs && !creature->getNpc())) {
+				if ((onlyPlayers && !creature->getPlayerRaw()) || (onlyMonsters && !creature->getMonsterRaw()) || (onlyNpcs && !creature->getNpcRaw())) {
 					continue;
 				}
 			}
@@ -258,7 +258,7 @@ Spectators Spectators::excludeMaster() const {
 	specs.creatures.reserve(creatures.size());
 
 	for (const auto &c : creatures) {
-		if (c->getMonster() != nullptr && !c->getMaster()) {
+		if (c->getMonsterRaw() != nullptr && !c->getMaster()) {
 			specs.creatures.emplace_back(c);
 		}
 	}
@@ -275,7 +275,8 @@ Spectators Spectators::excludePlayerMaster() const {
 	specs.creatures.reserve(creatures.size());
 
 	for (const auto &c : creatures) {
-		if ((c->getMonster() != nullptr && !c->getMaster()) || (!c->getMaster() || !c->getMaster()->getPlayer())) {
+		const auto &master = c->getMaster();
+		if ((c->getMonsterRaw() != nullptr && !master) || (!master || !master->getPlayerRaw())) {
 			specs.creatures.emplace_back(c);
 		}
 	}
@@ -288,7 +289,7 @@ Spectators Spectators::filter(bool onlyPlayers, bool onlyMonsters, bool onlyNpcs
 	specs.creatures.reserve(creatures.size());
 
 	for (const auto &c : creatures) {
-		if ((onlyPlayers && c->getPlayer() != nullptr) || (onlyMonsters && c->getMonster() != nullptr) || (onlyNpcs && c->getNpc() != nullptr)) {
+		if ((onlyPlayers && c->getPlayerRaw() != nullptr) || (onlyMonsters && c->getMonsterRaw() != nullptr) || (onlyNpcs && c->getNpcRaw() != nullptr)) {
 			specs.creatures.emplace_back(c);
 		}
 	}

--- a/src/map/utils/mapsector.cpp
+++ b/src/map/utils/mapsector.cpp
@@ -23,11 +23,11 @@ bool MapSector::newSector = false;
 
 void MapSector::addCreature(const std::shared_ptr<Creature> &c) {
 	creature_list.emplace_back(c);
-	if (c->getPlayer()) {
+	if (c->getPlayerRaw()) {
 		player_list.emplace_back(c);
-	} else if (c->getMonster()) {
+	} else if (c->getMonsterRaw()) {
 		monster_list.emplace_back(c);
-	} else if (c->getNpc()) {
+	} else if (c->getNpcRaw()) {
 		npc_list.emplace_back(c);
 	}
 }
@@ -43,7 +43,7 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 	*iter = creature_list.back();
 	creature_list.pop_back();
 
-	if (c->getPlayer()) {
+	if (c->getPlayerRaw()) {
 		iter = std::ranges::find(player_list, c);
 		if (iter == player_list.end()) {
 			g_logger().error("[{}]: Player not found in player_list!", __FUNCTION__);
@@ -53,20 +53,20 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 		assert(iter != player_list.end());
 		*iter = player_list.back();
 		player_list.pop_back();
-	} else if (c->getMonster()) {
+	} else if (c->getMonsterRaw()) {
 		iter = std::ranges::find(monster_list, c);
 		if (iter == monster_list.end()) {
-			g_logger().error("[{}]: Monster not found in player_list!", __FUNCTION__);
+			g_logger().error("[{}]: Monster not found in monster_list!", __FUNCTION__);
 			return;
 		}
 
 		assert(iter != monster_list.end());
 		*iter = monster_list.back();
 		monster_list.pop_back();
-	} else if (c->getNpc()) {
+	} else if (c->getNpcRaw()) {
 		iter = std::ranges::find(npc_list, c);
 		if (iter == npc_list.end()) {
-			g_logger().error("[{}]: NPC not found in player_list!", __FUNCTION__);
+			g_logger().error("[{}]: NPC not found in npc_list!", __FUNCTION__);
 			return;
 		}
 

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -40,6 +40,7 @@
 #include <forward_list>
 #include <list>
 #include <map>
+#include <memory>
 #include <unordered_set>
 #include <queue>
 #include <random>
@@ -48,6 +49,7 @@
 #include <regex>
 #include <set>
 #include <thread>
+#include <type_traits>
 #include <vector>
 #include <variant>
 #include <numeric>


### PR DESCRIPTION
## What

Introduces a typed Lua shared-userdata layer, fixes several `std::shared_ptr` ownership leaks in the Lua bindings, and reduces `shared_from_this()` refcount churn in the movement/spectator hot paths.

### Lua shared-userdata typing & leak fixes

- New typed helpers in `src/lua/functions/lua_functions_loader.hpp`: `LuaUserdataTraits<T>`, `getUserdataMetatableName<T>()`, `pushSharedUserdata<T>`, `pushBorrowedSharedUserdata<T>`, `registerSharedClass<T>` and a typed `__gc` (`luaSharedPtrGarbageCollection<T>`). These tie the C++ type, the Lua metatable name and the finalizer together at compile time.
- Fixed memory leaks where a `std::shared_ptr<T>` stored in userdata was never released because the metatable had no (or a stripped) `__gc`:
  - **KV** (`kv:scoped()`, `player:kv()`) was registered with `registerClass` (no `__gc`).
  - **Condition** returned by `creature:getCondition()` used `setWeakMetatable`, which removes `__gc`.
  - Borrowed **NetworkMessage** in the module `onRecvbyte` callback was wrapped in `std::shared_ptr<NetworkMessage>(&msg)` under a weak metatable — now uses a no-op-deleter borrowed push with the typed finalizer.
- Migrated the non-`SharedObject` bindings to the typed path: Combat, Spell, Zone, Charm, Loot, MonsterType, MonsterSpell, Shop, Group, Guild, Vocation, Mount, Town, Action, TalkAction, CreatureEvent, GlobalEvent, EventCallback, ModalWindow, Weapon.
- Drive-by correctness fixes:
  - `combat:setCondition()` was reading a `shared_ptr` userdata through the raw-pointer getter.
  - `position:getZones()` was writing the zones into the argument table instead of a fresh result table.
- The legacy untyped helpers are kept (still used by the polymorphic `SharedObject` core types — `Creature`/`Player`/`Monster`/`Npc`/`Item`/`Container`/`Tile`/`Teleport`) but marked `[[deprecated]]`; C4996 is suppressed on MSVC to match the existing GCC `-Wno-deprecated-declarations`.

### Movement / spectator hot paths

- Added raw type accessors `getPlayerRaw()/getMonsterRaw()/getNpcRaw()` to avoid `shared_from_this()` churn in `Spectators`, `MapSector`, `Map::moveCreature` and `Game::removeCreature` (local `Player*` vectors anchored by the existing strong spectator snapshot; raw pointers stay local to the scope).
- Added raw `Player*` overloads of `Tile::getClientIndexOfCreature` / `Tile::getStackposOfCreature` (the `shared_ptr` overloads now delegate to them).
- Removed an unnecessary self `shared_ptr` construction in `Monster` hot paths (`addFriend`/`addTarget`/`searchTarget`).

### Docs

- Added `docs/systems/lua-shared-userdata.md` documenting the ownership contract, the helper API and a review checklist.

## Notes

- Ownership semantics are unchanged: spectators and cache storage stay `shared_ptr`; raw `Player*` values are local only and lifetime-anchored by the spectator snapshot in the same scope.
- The polymorphic core userdata types are intentionally left on the legacy path; they need a separate audit before migrating.
