### PR TITLE
fix: Refactor chain combat to separate initial and chain damage

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1318,7 +1318,7 @@ void Combat::setupChain(const std::shared_ptr<Weapon> &weapon) {
 	}
 }
 
-bool Combat::doCombatChain(const std::shared_ptr<Creature> &caster, const std::shared_ptr<Creature> &target, bool aggressive) const {
+bool Combat::doCombatChain(const std::shared_ptr<Creature> &caster, const std::shared_ptr<Creature> &target, bool aggressive, bool disableFirstTarget /* = false */) const {
 	metrics::method_latency measure(__METRICS_METHOD_NAME__);
 	if (!params.chainCallback) {
 		return false;
@@ -1339,6 +1339,10 @@ bool Combat::doCombatChain(const std::shared_ptr<Creature> &caster, const std::s
 	int i = 0;
 	auto combat = this;
 	for (const auto &[from, toVector] : targets) {
+		if (disableFirstTarget) {
+			disableFirstTarget = false;
+			continue;
+		}
 		auto delay = i * std::max<int32_t>(50, g_configManager().getNumber(COMBAT_CHAIN_DELAY));
 		++i;
 		for (const auto &to : toVector) {
@@ -1347,10 +1351,14 @@ bool Combat::doCombatChain(const std::shared_ptr<Creature> &caster, const std::s
 				continue;
 			}
 			g_dispatcher().scheduleEvent(
-				delay, [combat, caster, nextTarget, from, affected]() {
+				delay, [combat, caster, nextTarget, affected]() {
 					if (combat && caster && nextTarget) {
-						Combat::doChainEffect(from, nextTarget->getPosition(), combat->params.chainEffect);
-						combat->doCombat(caster, nextTarget, from, affected);
+						CombatDamage damage = combat->getCombatDamage(caster, nextTarget);
+						damage.affected = affected;
+						Combat::CombatHealthFunc(caster, nextTarget, combat->params, &damage);
+						if (combat->params.targetCallback) {
+							combat->params.targetCallback->onTargetCombat(caster, nextTarget);
+						}
 					}
 				},
 				"Combat::doCombatChain"

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -253,7 +253,7 @@ public:
 	void setRuneSpellName(const std::string &value);
 
 	void setupChain(const std::shared_ptr<Weapon> &weapon);
-	bool doCombatChain(const std::shared_ptr<Creature> &caster, const std::shared_ptr<Creature> &target, bool aggressive) const;
+	bool doCombatChain(const std::shared_ptr<Creature> &caster, const std::shared_ptr<Creature> &target, bool aggressive, bool disableFirstTarget = false) const;
 
 private:
 	static void doChainEffect(const Position &origin, const Position &pos, uint8_t effect);

--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -373,11 +373,8 @@ void Weapon::internalUseWeapon(const std::shared_ptr<Player> &player, const std:
 			if (selfWeapon) {
 				m_combat->setupChain(selfWeapon);
 			}
-			if (!m_combat->doCombatChain(player, target, params.aggressive)) {
-				Combat::doCombatHealth(player, target, damage, params);
-			} else {
-				g_logger().debug("Weapon::internalUseWeapon - Chain executed with distance effects.");
-			}
+			Combat::doCombatHealth(player, target, damage, params);
+			m_combat->doCombatChain(player, target, params.aggressive, true);
 		} else {
 			Combat::doCombatHealth(player, target, damage, params);
 		}


### PR DESCRIPTION
Modify weapon combat to always apply damage to the initial target first, then apply chain effects to subsequent targets. This is achieved by:
- Adding a `disableFirstTarget` parameter to `doCombatChain` to skip the first chain target
- Restructuring weapon attack flow to always call `doCombatHealth` for the initial target
- Updating chain effect execution to use `getCombatDamage` and `CombatHealthFunc` directly for consistency

This ensures the primary target is always hit first before chain effects are applied to other targets.