### PR TITLE
fix: Add Market offer limits to prevent disconnect

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -10134,6 +10134,22 @@ void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t ite
 		return;
 	}
 
+	// Check limit of own offers per side (buy/sell)
+	const uint32_t playerOfferCountPerSide = IOMarket::getPlayerOfferCountPerSide(player->getGUID(), static_cast<MarketAction_t>(type));
+	if (playerOfferCountPerSide >= IOMarket::MAX_MARKET_OWN_OFFERS_PER_SIDE) {
+		player->sendTextMessage(MESSAGE_MARKET, "You have reached the maximum number of offers per side. Cancel some offers before creating new ones.");
+		g_logger().warn("{} - Player {} reached own offers per side limit ({})", __FUNCTION__, player->getName(), IOMarket::MAX_MARKET_OWN_OFFERS_PER_SIDE);
+		return;
+	}
+
+	// Check limit of offers per item per side (buy/sell)
+	const uint32_t itemOfferCountPerSide = IOMarket::getItemOfferCountPerSide(it.id, tier, static_cast<MarketAction_t>(type));
+	if (itemOfferCountPerSide >= IOMarket::MAX_MARKET_OFFERS_PER_SIDE) {
+		player->sendTextMessage(MESSAGE_MARKET, "There are too many offers for this item. Try again later or choose a different item.");
+		g_logger().warn("{} - Player {} reached item offers per side limit ({}) for item {}", __FUNCTION__, player->getName(), IOMarket::MAX_MARKET_OFFERS_PER_SIDE, it.id);
+		return;
+	}
+
 	if (!player->canDoMarketAction()) {
 		player->sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
 		return;

--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -42,8 +42,10 @@ MarketOfferList IOMarket::getActiveOffers(MarketAction_t action) {
 	std::string query = fmt::format(
 		"SELECT `id`, `itemtype`, `amount`, `price`, `tier`, `created`, `anonymous`, "
 		"(SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `player_name` "
-		"FROM `market_offers` WHERE `sale` = {}",
-		action
+		"FROM `market_offers` WHERE `sale` = {} "
+		"ORDER BY `id` DESC "
+		"LIMIT {}",
+		action, MAX_MARKET_OFFERS_RETURNED
 	);
 
 	DBResult_ptr result = g_database().storeQuery(query);
@@ -75,7 +77,7 @@ MarketOfferList IOMarket::getActiveOffers(MarketAction_t action, uint16_t itemId
 	MarketOfferList offerList;
 
 	std::ostringstream query;
-	query << "SELECT `id`, `amount`, `price`, `tier`, `created`, `anonymous`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `player_name` FROM `market_offers` WHERE `sale` = " << action << " AND `itemtype` = " << itemId << " AND `tier` = " << std::to_string(tier);
+	query << "SELECT `id`, `amount`, `price`, `tier`, `created`, `anonymous`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `player_name` FROM `market_offers` WHERE `sale` = " << action << " AND `itemtype` = " << itemId << " AND `tier` = " << std::to_string(tier) << " ORDER BY `id` DESC LIMIT " << MAX_MARKET_OFFERS_PER_SIDE;
 
 	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
 	if (!result) {
@@ -256,6 +258,28 @@ void IOMarket::checkExpiredOffers() {
 uint32_t IOMarket::getPlayerOfferCount(uint32_t playerId) {
 	std::ostringstream query;
 	query << "SELECT COUNT(*) AS `count` FROM `market_offers` WHERE `player_id` = " << playerId;
+
+	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	if (!result) {
+		return 0;
+	}
+	return result->getNumber<int32_t>("count");
+}
+
+uint32_t IOMarket::getPlayerOfferCountPerSide(uint32_t playerId, MarketAction_t action) {
+	std::ostringstream query;
+	query << "SELECT COUNT(*) AS `count` FROM `market_offers` WHERE `player_id` = " << playerId << " AND `sale` = " << action;
+
+	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	if (!result) {
+		return 0;
+	}
+	return result->getNumber<int32_t>("count");
+}
+
+uint32_t IOMarket::getItemOfferCountPerSide(uint16_t itemId, uint8_t tier, MarketAction_t action) {
+	std::ostringstream query;
+	query << "SELECT COUNT(*) AS `count` FROM `market_offers` WHERE `itemtype` = " << itemId << " AND `tier` = " << std::to_string(tier) << " AND `sale` = " << action;
 
 	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
 	if (!result) {

--- a/src/io/iomarket.hpp
+++ b/src/io/iomarket.hpp
@@ -29,6 +29,10 @@ public:
 		return inject<IOMarket>();
 	}
 
+	static constexpr uint32_t MAX_MARKET_OFFERS_RETURNED = 1500;
+	static constexpr uint32_t MAX_MARKET_OFFERS_PER_SIDE = 700;
+	static constexpr uint32_t MAX_MARKET_OWN_OFFERS_PER_SIDE = 1000;
+
 	static MarketOfferList getActiveOffers(MarketAction_t action);
 	static MarketOfferList getActiveOffers(MarketAction_t action, uint16_t itemId, uint8_t tier);
 	static MarketOfferList getOwnOffers(MarketAction_t action, uint32_t playerId);
@@ -38,6 +42,8 @@ public:
 	static void checkExpiredOffers();
 
 	static uint32_t getPlayerOfferCount(uint32_t playerId);
+	static uint32_t getPlayerOfferCountPerSide(uint32_t playerId, MarketAction_t action);
+	static uint32_t getItemOfferCountPerSide(uint16_t itemId, uint8_t tier, MarketAction_t action);
 	static MarketOfferEx getOfferByCounter(uint32_t timestamp, uint16_t counter);
 
 	static void createOffer(uint32_t playerId, MarketAction_t action, uint32_t itemId, uint16_t amount, uint64_t price, uint8_t tier, bool anonymous);


### PR DESCRIPTION
Enforce per-player and per-item per-side market offer limits and cap returned results. 
- Adds constants (MAX_MARKET_OFFERS_RETURNED=1500, MAX_MARKET_OFFERS_PER_SIDE=700, MAX_MARKET_OWN_OFFERS_PER_SIDE=1000) to IOMarket.hpp. 
- Game::playerCreateMarketOffer now checks player and item per-side counts and blocks new offers with user message and log when limits are reached. 
- IOMarket query functions now ORDER BY id DESC and apply LIMITs to reduce result set size. New DB helpers IOMarket::getPlayerOfferCountPerSide and IOMarket::getItemOfferCountPerSide added; DB failures return 0. Purpose: reduce DB load and mitigate market spam.

## Market Bug
[Market Bug](https://imgur.com/a/database-market-bug-Fj1tSC1)