### PR TITLE
fix: Replace dynamic arrays with vectors in MatrixArea

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2886,42 +2886,16 @@ int32_t MagicField::getDamage() const {
 }
 
 MatrixArea::MatrixArea(uint32_t initRows, uint32_t initCols) :
-	centerX(0), centerY(0), rows(initRows), cols(initCols) {
-	data_ = new bool*[rows];
-
-	for (uint32_t row = 0; row < rows; ++row) {
-		data_[row] = new bool[cols];
-
-		for (uint32_t col = 0; col < cols; ++col) {
-			data_[row][col] = false;
-		}
-	}
+	centerX(0), centerY(0), rows(initRows), cols(initCols),
+	data_(initRows, std::vector<char>(initCols, 0)) {
 }
 
-MatrixArea::MatrixArea(const MatrixArea &rhs) {
-	centerX = rhs.centerX;
-	centerY = rhs.centerY;
-	rows = rhs.rows;
-	cols = rhs.cols;
-
-	data_ = new bool*[rows];
-
-	for (uint32_t row = 0; row < rows; ++row) {
-		data_[row] = new bool[cols];
-
-		for (uint32_t col = 0; col < cols; ++col) {
-			data_[row][col] = rhs.data_[row][col];
-		}
-	}
+MatrixArea::MatrixArea(const MatrixArea &rhs) :
+	centerX(rhs.centerX), centerY(rhs.centerY), rows(rhs.rows), cols(rhs.cols),
+	data_(rhs.data_) {
 }
 
-MatrixArea::~MatrixArea() {
-	for (uint32_t row = 0; row < rows; ++row) {
-		delete[] data_[row];
-	}
-
-	delete[] data_;
-}
+MatrixArea::~MatrixArea() = default;
 
 std::unique_ptr<MatrixArea> MatrixArea::clone() const {
 	return std::make_unique<MatrixArea>(*this);
@@ -2929,7 +2903,7 @@ std::unique_ptr<MatrixArea> MatrixArea::clone() const {
 
 void MatrixArea::setValue(uint32_t row, uint32_t col, bool value) const {
 	if (row < rows && col < cols) {
-		data_[row][col] = value;
+		data_[row][col] = value ? 1 : 0;
 	} else {
 		g_logger().error("[{}] Access exceeds the upper limit of memory block");
 		throw std::out_of_range("Access exceeds the upper limit of memory block");
@@ -2937,7 +2911,7 @@ void MatrixArea::setValue(uint32_t row, uint32_t col, bool value) const {
 }
 
 bool MatrixArea::getValue(uint32_t row, uint32_t col) const {
-	return data_[row][col];
+	return data_[row][col] != 0;
 }
 
 void MatrixArea::setCenter(uint32_t y, uint32_t x) {
@@ -2958,11 +2932,11 @@ uint32_t MatrixArea::getCols() const {
 	return cols;
 }
 const bool* MatrixArea::operator[](uint32_t i) const {
-	return data_[i];
+	return reinterpret_cast<const bool*>(data_[i].data());
 }
 
 bool* MatrixArea::operator[](uint32_t i) {
-	return data_[i];
+	return reinterpret_cast<bool*>(data_[i].data());
 }
 
 CombatDamage Combat::applyWeaponProficiencyDamage(const std::shared_ptr<Player> &attackerPlayer, std::shared_ptr<Item> item, std::shared_ptr<Monster> &targetMonster, CombatDamage damage) {

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2901,7 +2901,7 @@ std::unique_ptr<MatrixArea> MatrixArea::clone() const {
 	return std::make_unique<MatrixArea>(*this);
 }
 
-void MatrixArea::setValue(uint32_t row, uint32_t col, bool value) const {
+void MatrixArea::setValue(uint32_t row, uint32_t col, bool value) {
 	if (row < rows && col < cols) {
 		data_[row][col] = value ? 1 : 0;
 	} else {

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2905,7 +2905,7 @@ void MatrixArea::setValue(uint32_t row, uint32_t col, bool value) {
 	if (row < rows && col < cols) {
 		data_[row][col] = value ? 1 : 0;
 	} else {
-		g_logger().error("[MatrixArea::setValue] Access exceeds the upper limit of memory block");
+		g_logger().error("[{}] Access exceeds the upper limit of memory block");
 		throw std::out_of_range("Access exceeds the upper limit of memory block");
 	}
 }
@@ -2930,6 +2930,13 @@ uint32_t MatrixArea::getRows() const {
 
 uint32_t MatrixArea::getCols() const {
 	return cols;
+}
+const bool* MatrixArea::operator[](uint32_t i) const {
+	return reinterpret_cast<const bool*>(data_[i].data());
+}
+
+bool* MatrixArea::operator[](uint32_t i) {
+	return reinterpret_cast<bool*>(data_[i].data());
 }
 
 CombatDamage Combat::applyWeaponProficiencyDamage(const std::shared_ptr<Player> &attackerPlayer, std::shared_ptr<Item> item, std::shared_ptr<Monster> &targetMonster, CombatDamage damage) {

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2905,7 +2905,7 @@ void MatrixArea::setValue(uint32_t row, uint32_t col, bool value) {
 	if (row < rows && col < cols) {
 		data_[row][col] = value ? 1 : 0;
 	} else {
-		g_logger().error("[{}] Access exceeds the upper limit of memory block");
+		g_logger().error("[MatrixArea::setValue] Access exceeds the upper limit of memory block");
 		throw std::out_of_range("Access exceeds the upper limit of memory block");
 	}
 }
@@ -2930,13 +2930,6 @@ uint32_t MatrixArea::getRows() const {
 
 uint32_t MatrixArea::getCols() const {
 	return cols;
-}
-const bool* MatrixArea::operator[](uint32_t i) const {
-	return reinterpret_cast<const bool*>(data_[i].data());
-}
-
-bool* MatrixArea::operator[](uint32_t i) {
-	return reinterpret_cast<bool*>(data_[i].data());
 }
 
 CombatDamage Combat::applyWeaponProficiencyDamage(const std::shared_ptr<Player> &attackerPlayer, std::shared_ptr<Item> item, std::shared_ptr<Monster> &targetMonster, CombatDamage damage) {

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -136,7 +136,7 @@ public:
 	// non-assignable
 	MatrixArea &operator=(const MatrixArea &) = delete;
 
-	void setValue(uint32_t row, uint32_t col, bool value) const;
+	void setValue(uint32_t row, uint32_t col, bool value);
 	bool getValue(uint32_t row, uint32_t col) const;
 
 	void setCenter(uint32_t y, uint32_t x);

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "items/item.hpp"
 #include "lua/global/baseevents.hpp"
 #include "creatures/monsters/monster.hpp"
@@ -152,7 +154,7 @@ private:
 
 	uint32_t rows;
 	uint32_t cols;
-	bool** data_;
+	std::vector<std::vector<char>> data_;
 };
 
 class AreaCombat {

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -145,9 +145,6 @@ public:
 	uint32_t getRows() const;
 	uint32_t getCols() const;
 
-	const bool* operator[](uint32_t i) const;
-	bool* operator[](uint32_t i);
-
 private:
 	uint32_t centerX;
 	uint32_t centerY;

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -145,6 +145,9 @@ public:
 	uint32_t getRows() const;
 	uint32_t getCols() const;
 
+	const bool* operator[](uint32_t i) const;
+	bool* operator[](uint32_t i);
+
 private:
 	uint32_t centerX;
 	uint32_t centerY;


### PR DESCRIPTION
Refactor MatrixArea to use std::vector instead of manual 2D dynamic array allocation.
This modernizes the code by leveraging STL containers for automatic memory management, eliminates manual new/delete operations, and improves safety.
The destructor is now defaulted since vectors handle their own cleanup.