### PR TITLE
fix: Delegate Bakragore icon sending to sendIcons

### DIFF
--- a/data/scripts/talkactions/god/icons_functions.lua
+++ b/data/scripts/talkactions/god/icons_functions.lua
@@ -18,13 +18,10 @@ function Player:sendNormalIcons(icons)
 	msg:sendToPlayer(self)
 end
 
-function Player:sendIconBakragore(specialIcon)
-	local msg = NetworkMessage()
-	msg:addByte(0xA2)
-	msg:addU64(0)
-	msg:addByte(specialIcon)
-	msg:sendToPlayer(self)
-end
+-- Player:sendIconBakragore now delegates to the engine's sendIcons()
+-- which reads current normal icons + Bakragore condition and sends
+-- the combined 0xA2 packet without wiping normal icons.
+-- Use /bakragoreicon <N> to set a persistent Bakragore taint icon.
 
 --[[
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2208,10 +2208,10 @@ void Player::sendIcons() {
 	client->sendIcons(iconSet, iconBakragore);
 }
 
-void Player::sendIconBakragore(IconBakragore icon) const {
-	if (client) {
-		client->sendIconBakragore(icon);
-	}
+void Player::sendIconBakragore(IconBakragore icon) {
+	// sendIcons() reads both normal conditions and Bakragore
+	// condition to send the correct combined 0xA2 packet.
+	sendIcons();
 }
 
 void Player::removeBakragoreIcons() {
@@ -2223,8 +2223,9 @@ void Player::removeBakragoreIcons() {
 }
 
 void Player::removeBakragoreIcon(const IconBakragore icon) {
-	if (hasCondition(CONDITION_BAKRAGORE, enumToValue(icon))) {
-		removeCondition(CONDITION_BAKRAGORE, CONDITIONID_DEFAULT, true);
+	const auto &condition = getCondition(CONDITION_BAKRAGORE, CONDITIONID_DEFAULT, enumToValue(icon));
+	if (condition) {
+		removeCondition(condition);
 	}
 }
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1072,7 +1072,7 @@ public:
 	void sendCreatePrivateChannel(uint16_t channelId, const std::string &channelName) const;
 	void sendClosePrivate(uint16_t channelId);
 	void sendIcons();
-	void sendIconBakragore(IconBakragore icon) const;
+	void sendIconBakragore(IconBakragore icon);
 	void removeBakragoreIcons();
 	void removeBakragoreIcon(const IconBakragore icon);
 	void sendClientCheck() const;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5400,14 +5400,6 @@ void ProtocolGame::sendIcons(const std::unordered_set<PlayerIcon> &iconSet, cons
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendIconBakragore(const IconBakragore icon) {
-	NetworkMessage msg;
-	msg.addByte(0xA2);
-	msg.add<uint64_t>(0); // Send empty normal icons
-	msg.addByte(enumToValue(icon));
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendUnjustifiedPoints(const uint8_t &dayProgress, const uint8_t &dayLeft, const uint8_t &weekProgress, const uint8_t &weekLeft, const uint8_t &monthProgress, const uint8_t &monthLeft, const uint8_t &skullDuration) {
 	NetworkMessage msg;
 	msg.addByte(0xB7);

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -298,7 +298,6 @@ private:
 	void sendToChannel(const std::shared_ptr<Creature> &creature, SpeakClasses type, const std::string &text, uint16_t channelId);
 	void sendPrivateMessage(const std::shared_ptr<Player> &speaker, SpeakClasses type, const std::string &text);
 	void sendIcons(const std::unordered_set<PlayerIcon> &iconSet, const IconBakragore iconBakragore);
-	void sendIconBakragore(const IconBakragore icon);
 	void sendFYIBox(const std::string &message);
 
 	void openImbuementWindow(const Imbuement_Window_t type, const std::shared_ptr<Item> &item = nullptr);


### PR DESCRIPTION
This PR fixes issue #576 

Remove the separate sendIconBakragore path and let Player::sendIcons produce the combined 0xA2 packet (so normal icons aren't wiped). Updates:
- data/scripts/.../icons_functions.lua: remove Lua helper and add comment pointing to engine behavior.
- src/creatures/players/player.cpp/.hpp: make sendIconBakragore non-const and delegate to sendIcons; use getCondition/removeCondition for precise Bakragore removal.
- src/server/network/protocol/protocolgame.*: remove ProtocolGame::sendIconBakragore implementation and declaration.
Reason: preserve normal icons when applying a Bakragore taint icon and simplify sending logic.