### PR TITLE
fix: Optimize player GUID lookup with direct index

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1152,11 +1152,12 @@ std::shared_ptr<Player> Game::getPlayerByGUID(const uint32_t &guid, bool allowOf
 	if (guid == 0) {
 		return nullptr;
 	}
-	for (const auto &it : players) {
-		if (guid == it.second->getGUID()) {
-			return it.second;
-		}
+
+	auto it = playersByGUID.find(guid);
+	if (it != playersByGUID.end()) {
+		return it->second;
 	}
+
 	if (!allowOffline) {
 		return nullptr;
 	}
@@ -11282,6 +11283,7 @@ void Game::addPlayer(const std::shared_ptr<Player> &player) {
 	mappedPlayerNames[lowercase_name] = player;
 	wildcardTree->insert(lowercase_name);
 	players[player->getID()] = player;
+	playersByGUID[player->getGUID()] = player;
 }
 
 void Game::removePlayer(const std::shared_ptr<Player> &player) {
@@ -11289,6 +11291,7 @@ void Game::removePlayer(const std::shared_ptr<Player> &player) {
 	mappedPlayerNames.erase(lowercase_name);
 	wildcardTree->remove(lowercase_name);
 	players.erase(player->getID());
+	playersByGUID.erase(player->getGUID());
 }
 
 void Game::addNpc(const std::shared_ptr<Npc> &npc) {

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -897,6 +897,7 @@ private:
 
 	std::unordered_map<std::string, std::weak_ptr<Player>> m_deadPlayers;
 	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Player>> players;
+	phmap::flat_hash_map<uint32_t, std::shared_ptr<Player>> playersByGUID;
 	phmap::flat_hash_map<std::string, std::weak_ptr<Player>> mappedPlayerNames;
 	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Guild>> guilds;
 	phmap::flat_hash_map<uint16_t, std::shared_ptr<Item>> uniqueItems;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -897,7 +897,7 @@ private:
 
 	std::unordered_map<std::string, std::weak_ptr<Player>> m_deadPlayers;
 	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Player>> players;
-	phmap::flat_hash_map<uint32_t, std::shared_ptr<Player>> playersByGUID;
+	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Player>> playersByGUID;
 	phmap::flat_hash_map<std::string, std::weak_ptr<Player>> mappedPlayerNames;
 	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Guild>> guilds;
 	phmap::flat_hash_map<uint16_t, std::shared_ptr<Item>> uniqueItems;


### PR DESCRIPTION
Add a dedicated playersByGUID hash map to enable O(1) player lookups by GUID instead of linear search through the players map. Maintain the new index during player add/remove operations.