### PR TITLE
fix: action script bugs and extend enchanting

### DIFF
--- a/data-global/scripts/actions/other/enchanting.lua
+++ b/data-global/scripts/actions/other/enchanting.lua
@@ -99,7 +99,7 @@ function enchanting.onUse(player, item, fromPosition, target, toPosition, isHotk
 		player:addMana(-mana)
 		player:addSoul(-soul)
 		item:transform(enchantedGems[targetId])
-		player:addManaSpent(items.valuables.mana)
+		player:addManaSpent(mana)
 		player:getPosition():sendMagicEffect(CONST_ME_HOLYDAMAGE)
 		return true
 	end
@@ -136,5 +136,5 @@ function enchanting.onUse(player, item, fromPosition, target, toPosition, isHotk
 	return false
 end
 
-enchanting:id(675, 676, 677, 678)
+enchanting:id(675, 676, 677, 678, 3029, 3030, 3032, 3033)
 enchanting:register()

--- a/data-global/scripts/actions/other/fishing.lua
+++ b/data-global/scripts/actions/other/fishing.lua
@@ -177,6 +177,10 @@ end
 local fishing = Action()
 
 function fishing.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if not target then
+		return false
+	end
+
 	if not table.contains(waterIds, target.itemid) then
 		return false
 	end

--- a/data-global/scripts/actions/tools/skinning.lua
+++ b/data-global/scripts/actions/tools/skinning.lua
@@ -304,7 +304,9 @@ function skinning.onUse(player, item, fromPosition, target, toPosition, isHotkey
 
 	if transform then
 		local corpse = topItem or target
-		corpse:transform(skin.after or corpse:getType():getDecayId() or corpse.itemid + 1)
+		if corpse then
+			corpse:transform(skin.after or corpse:getType():getDecayId() or (corpse.itemid + 1))
+		end
 	else
 		target:remove()
 	end

--- a/data-global/scripts/actions/tools/skinning.lua
+++ b/data-global/scripts/actions/tools/skinning.lua
@@ -303,7 +303,8 @@ function skinning.onUse(player, item, fromPosition, target, toPosition, isHotkey
 	end
 
 	if transform then
-		topItem:transform(skin.after or topItem:getType():getDecayId() or topItem.itemid + 1)
+		local corpse = topItem or target
+		corpse:transform(skin.after or corpse:getType():getDecayId() or corpse.itemid + 1)
 	else
 		target:remove()
 	end


### PR DESCRIPTION
- Fix enchanting: use correct mana variable instead of invalid reference
- Add new item IDs (3029, 3030, 3032, 3033) to enchanting action registry
- Add null check for target in fishing action
- Fix skinning transformation to use correct corpse variable reference