### PR TITLE
fix: Unify spell damage formulas to use basePower

### DIFF
--- a/data/scripts/spells/attack/divine_barrage.lua
+++ b/data/scripts/spells/attack/divine_barrage.lua
@@ -1,23 +1,12 @@
--- Divine Barrage (Paladin) - Vocation Adjustment
--- Crosshair/target spell: needTarget + setArea so the engine resolves the
--- target creature and applies a diamond burst (AREA_CIRCLE2X2, 13-square
--- diamond-arrow-size) centered on the target's tile.
--- Holy damage, scales with MAGIC LEVEL like Divine Caldera (LEVELMAGICVALUE).
-
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HOLYDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, 319)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SMALLHOLY)
 combat:setArea(createCombatArea(AREA_CIRCLE2X2))
 
--- Base 140. Scales with magic level (and a little with level) like Divine Caldera.
-local BASE = 140
-local DAMAGE_SCALE = BASE / 140
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 4)
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 6)
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")
@@ -25,7 +14,6 @@ combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, var)
-	-- needPosition: var is the clicked tile (cursor/crosshair); the area is cast there.
 	return combat:execute(creature, var)
 end
 
@@ -36,11 +24,12 @@ spell:words("exori dir san")
 spell:castSound(SOUND_EFFECT_TYPE_SPELL_DIVINE_CALDERA)
 spell:level(70)
 spell:mana(175)
-spell:basePower(140)
+spell:basePower(130)
 spell:isPremium(true)
 spell:isAggressive(true)
 spell:range(7)
-spell:needPosition(true) -- cast at the clicked tile (cursor/crosshair); var is VARIANT_POSITION
+spell:needPosition(true)
+spell:needTarget(true)
 spell:blockWalls(true)
 spell:needLearn(false)
 spell:cooldown(4 * 1000)

--- a/data/scripts/spells/attack/divine_caldera.lua
+++ b/data/scripts/spells/attack/divine_caldera.lua
@@ -3,13 +3,11 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HOLYDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HOLYAREA)
 combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
--- LIVE rebalance: base 140 -> 160.
-local DAMAGE_SCALE = 160 / 140
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 4)
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 6)
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local levelBonus = calculateBaseDamageHealing(level)
+	local min = (levelBonus + maglevel * 4) * basePower / 140
+	local max = (levelBonus + maglevel * 6) * basePower / 140
+	return -math.floor(min), -math.floor(max)
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

--- a/data/scripts/spells/attack/ethereal_barrage.lua
+++ b/data/scripts/spells/attack/ethereal_barrage.lua
@@ -1,10 +1,3 @@
--- Ethereal Barrage (Paladin) - Vocation Adjustment
--- Crosshair/target spell: needTarget + setArea so the engine resolves the
--- target creature and applies a diamond burst (AREA_CIRCLE2X2, 13-square
--- diamond-arrow-size) centered on the target's tile.
--- Physical damage, scales with DISTANCE FIGHTING like Strong Ethereal Spear
--- (SKILLVALUE callback: skill = effective distance skill, attack = weapon attack).
-
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, 320)
@@ -12,13 +5,9 @@ combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ETHEREALSPEAR)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
 combat:setArea(createCombatArea(AREA_CIRCLE2X2))
 
--- Base 40. Scales with distance fighting (and a little with level) like
--- Strong Ethereal Spear, tuned to a ~40 base hit.
-function onGetFormulaValues(player, skill, attack, factor)
-	local levelTotal = player:getLevel() / 5
-	local min = ((2 * skill + attack / 2500) * 1.20) + levelTotal + 7
-	local max = ((2 * skill + attack / 1875) * 2.00) + levelTotal + 13
-	return -min, -max
+function onGetFormulaValues(player, skill, attack, factor, basePower)
+	local avg = spellSkillDamage(basePower, player:getLevel(), skill, attack)
+	return -math.floor(avg * 0.9), -math.ceil(avg * 1.1)
 end
 
 combat:setCallback(CALLBACK_PARAM_SKILLVALUE, "onGetFormulaValues")
@@ -26,7 +15,6 @@ combat:setCallback(CALLBACK_PARAM_SKILLVALUE, "onGetFormulaValues")
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, var)
-	-- needPosition: var is the clicked tile (cursor/crosshair); the area is cast there.
 	return combat:execute(creature, var)
 end
 
@@ -38,14 +26,15 @@ spell:castSound(SOUND_EFFECT_TYPE_SPELL_STRONG_ETHEREAL_SPEAR)
 spell:impactSound(SOUND_EFFECT_TYPE_SPELL_STRONG_ETHEREAL_SPEAR)
 spell:level(60)
 spell:mana(135)
+spell:basePower(40)
 spell:isPremium(true)
 spell:isAggressive(true)
 spell:range(7)
-spell:needPosition(true) -- cast at the clicked tile (cursor/crosshair); var is VARIANT_POSITION
+spell:needPosition(true)
+spell:needTarget(true)
 spell:blockWalls(true)
 spell:needLearn(false)
 spell:cooldown(4 * 1000)
 spell:groupCooldown(2 * 1000)
-
 spell:vocation("paladin;true", "royal paladin;true")
 spell:register()

--- a/data/scripts/spells/attack/lightning.lua
+++ b/data/scripts/spells/attack/lightning.lua
@@ -2,21 +2,15 @@ local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
--- Vocation Adjustment: chains to 2 additional targets (3 total).
 combat:setParameter(COMBAT_PARAM_CHAIN_EFFECT, CONST_ME_PINK_ENERGY_SPARK)
 
--- Phase III LIVE rebalance: base 70 -> 110.
-local DAMAGE_SCALE = 110 / 70
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 2.2) + 12
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 3.4) + 21
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")
 
--- Vocation Adjustment: chain to 2 additional targets (3 total), jump distance 5.
 function getChainValue(creature)
 	return 3, 5, false
 end

--- a/data/scripts/spells/attack/strong_energy_strike.lua
+++ b/data/scripts/spells/attack/strong_energy_strike.lua
@@ -1,28 +1,16 @@
--- Vocation Adjustment: a Master Sorcerer's elemental stance reshapes Strong Energy Strike (element +
--- impact EFFECT id + MISSILE):
---   Master of Flames -> fire,  effect 329, missile 4
---   Master of Decay  -> death, effect 330, missile 11
---   Master of Thunder / no stance -> base energy (CONST_ME_ENERGYAREA / CONST_ANI_ENERGY)
-
--- Phase III LIVE rebalance: base 90 -> 125.
-local DAMAGE_SCALE = 125 / 90
-
-local function strikeFormula(level, maglevel)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 2.8) + 16
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 4.4) + 28
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+local function strikeFormula(level, maglevel, basePower)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
--- Each combat needs its OWN callback name (Canary won't let two combats share a callback name); all
--- three delegate to the same formula.
 function onGetFormulaValues(player, level, maglevel, basePower)
-	return strikeFormula(level, maglevel)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesFlames(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesFlames(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesDecay(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesDecay(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
 
 local function createStrikeCombat(combatType, effect, missile, callbackName)

--- a/data/scripts/spells/attack/strong_flame_strike.lua
+++ b/data/scripts/spells/attack/strong_flame_strike.lua
@@ -1,32 +1,18 @@
--- Vocation Adjustment: a Master Sorcerer's elemental stance reshapes Strong Flame Strike
--- (element + impact effect + missile):
---   Master of Thunder -> energy, effects [331, 333], missile 5
---   Master of Decay   -> death,  effects [332, 336], missile 11
---   Master of Flames / no stance -> base fire (CONST_ME_FIREATTACK, CONST_ANI_FIRE)
-
--- Phase III LIVE rebalance: base 90 -> 125.
-local DAMAGE_SCALE = 125 / 90
-
--- Shared formula; each combat needs its OWN callback name (Canary won't let two combats share a
--- callback name), so the variants delegate to this.
-local function strikeFormula(level, maglevel)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 2.8) + 16
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 4.4) + 28
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+local function strikeFormula(level, maglevel, basePower)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 function onGetFormulaValues(player, level, maglevel, basePower)
-	return strikeFormula(level, maglevel)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesThunder(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesThunder(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesDecay(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesDecay(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
 
--- Second impact effect (the first is set via COMBAT_PARAM_EFFECT) is delivered through a uniquely
--- named target callback per variant.
 function onTargetSecondEffectThunder(creature, target)
 	target:getPosition():sendMagicEffect(333)
 	return true
@@ -36,7 +22,6 @@ function onTargetSecondEffectDecay(creature, target)
 	return true
 end
 
--- Base combat (unchanged element/effect/missile).
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_FIREATTACK)

--- a/data/scripts/spells/attack/strong_ice_strike.lua
+++ b/data/scripts/spells/attack/strong_ice_strike.lua
@@ -3,13 +3,9 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ICEDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ICEATTACK)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SMALLICE)
 
--- Phase III LIVE rebalance: base 90 -> 115 (factor 1.278).
-local DAMAGE_SCALE = 115 / 90
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 2.8) + 16
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 4.4) + 28
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

--- a/data/scripts/spells/attack/strong_terra_strike.lua
+++ b/data/scripts/spells/attack/strong_terra_strike.lua
@@ -3,13 +3,9 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_CARNIPHILA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SMALLEARTH)
 
--- Phase III LIVE rebalance: base 90 -> 115 (factor 1.278).
-local DAMAGE_SCALE = 115 / 90
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 2.8) + 16
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 4.4) + 28
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

--- a/data/scripts/spells/attack/ultimate_energy_strike.lua
+++ b/data/scripts/spells/attack/ultimate_energy_strike.lua
@@ -1,28 +1,16 @@
--- Vocation Adjustment: a Master Sorcerer's elemental stance reshapes Ultimate Energy Strike (element +
--- impact EFFECT + missile DISTANCEEFFECT):
---   Master of Flames -> fire,  effect 329, missile 4
---   Master of Decay  -> death, effect 330, missile 11
---   Master of Thunder / no stance -> base energy (CONST_ME_ENERGYAREA / CONST_ANI_ENERGY)
-
--- Phase III LIVE rebalance: base 150 -> 210.
-local DAMAGE_SCALE = 210 / 150
-
-local function strikeFormula(level, maglevel)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 4.5) + 35
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 7.3) + 55
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+local function strikeFormula(level, maglevel, basePower)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
--- Each combat needs its OWN callback name (Canary won't let two combats share a callback name); all
--- three delegate to the same formula.
 function onGetFormulaValues(player, level, maglevel, basePower)
-	return strikeFormula(level, maglevel)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesFlames(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesFlames(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesDecay(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesDecay(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
 
 local function createStrikeCombat(combatType, effect, missile, callbackName)

--- a/data/scripts/spells/attack/ultimate_flame_strike.lua
+++ b/data/scripts/spells/attack/ultimate_flame_strike.lua
@@ -1,31 +1,18 @@
--- Vocation Adjustment: a Master Sorcerer's elemental stance reshapes Ultimate Flame Strike (element +
--- impact effect + missile):
---   Master of Thunder -> energy, effects 331+333, missile 5
---   Master of Decay   -> death,  effects 332+336, missile 11
---   Master of Flames / no stance -> base fire (CONST_ME_FIREATTACK, CONST_ANI_FIRE)
-
--- Phase III LIVE rebalance: base 150 -> 210.
-local DAMAGE_SCALE = 210 / 150
-
-local function strikeFormula(level, maglevel)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 4.5) + 35
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 7.3) + 55
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+local function strikeFormula(level, maglevel, basePower)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
--- Each combat needs its OWN callback name (Canary won't let two combats share a callback name); all
--- three delegate to the same formula.
 function onGetFormulaValues(player, level, maglevel, basePower)
-	return strikeFormula(level, maglevel)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesThunder(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesThunder(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
-function onGetFormulaValuesDecay(player, level, maglevel)
-	return strikeFormula(level, maglevel)
+function onGetFormulaValuesDecay(player, level, maglevel, basePower)
+	return strikeFormula(level, maglevel, basePower)
 end
 
--- Second-effect target callbacks (variants list two impact effects each).
 function onTargetSecondEffectThunder(creature, target)
 	target:getPosition():sendMagicEffect(333)
 	return true

--- a/data/scripts/spells/attack/ultimate_ice_strike.lua
+++ b/data/scripts/spells/attack/ultimate_ice_strike.lua
@@ -3,13 +3,9 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ICEDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ICEATTACK)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SMALLICE)
 
--- Phase III LIVE rebalance: base 150 -> 195 (factor 1.30).
-local DAMAGE_SCALE = 195 / 150
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 4.5) + 35
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 7.3) + 55
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

--- a/data/scripts/spells/attack/ultimate_terra_strike.lua
+++ b/data/scripts/spells/attack/ultimate_terra_strike.lua
@@ -3,13 +3,9 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_CARNIPHILA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SMALLEARTH)
 
--- Phase III LIVE rebalance: base 150 -> 195 (factor 1.30).
-local DAMAGE_SCALE = 195 / 150
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 4.5) + 35
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 7.3) + 55
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

--- a/data/scripts/spells/attack/wrath_of_nature.lua
+++ b/data/scripts/spells/attack/wrath_of_nature.lua
@@ -3,13 +3,9 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_SMALLPLANTS)
 combat:setArea(createCombatArea(AREA_CIRCLE6X6))
 
--- Phase III LIVE rebalance: base 150 -> 175 (factor 1.1667).
-local DAMAGE_SCALE = 175 / 150
-
 function onGetFormulaValues(player, level, maglevel, basePower)
-	local min = (calculateBaseDamageHealing(level)) + (maglevel * 5)
-	local max = (calculateBaseDamageHealing(level)) + (maglevel * 10)
-	return -math.floor(min * DAMAGE_SCALE), -math.floor(max * DAMAGE_SCALE)
+	local min, max = calculateMagicSpellDamage(level, maglevel, basePower)
+	return -min, -max
 end
 
 combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")


### PR DESCRIPTION
Replace ad-hoc damage scaling with unified helpers (calculateMagicSpellDamage / spellSkillDamage) and thread basePower through callbacks. Updated onGetFormulaValues signatures across many attack spells to accept basePower, removed legacy DAMAGE_SCALE constants, and ensured strikes/delegates pass basePower. Small behaviour tweaks: divine_barrage basePower set to 130 and needTarget enabled. Affected files: divine_barrage, divine_caldera, ethereal_barrage, lightning, strong_*/ultimate_*/wrath_of_nature. This centralizes spell balancing and enables per-spell basePower tuning.