### PR TITLE
fix: cd reduction perk

### DIFF
--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -756,7 +756,7 @@ int32_t Spell::calculateAugmentSpellCooldownReduction(const std::shared_ptr<Play
 	for (const auto &playerProficiencyAugment : player->getEquippedWeaponProficiency().spellAugments) {
 		if (playerProficiencyAugment.spellId == getSpellId()) {
 			if (playerProficiencyAugment.augmentType == PROFICIENCY_AUGMENTTYPE_COOLDOWN) {
-				const int32_t augmentValue = playerProficiencyAugment.value * 1;
+				const int32_t augmentValue = static_cast<int32_t>(playerProficiencyAugment.value * -1000.0f);
 				spellCooldown += augmentValue;
 			}
 		}
@@ -773,13 +773,12 @@ void Spell::applyCooldownConditions(const std::shared_ptr<Player> &player) const
 	if (std::abs(rateCooldown) < std::numeric_limits<float>::epsilon()) {
 		rateCooldown = 0.1; // Safe minimum value
 	}
-
+	int32_t augmentCooldownReduction = calculateAugmentSpellCooldownReduction(player);
 	if (cooldown > 0) {
 		int32_t spellCooldown = cooldown;
 		if (isUpgraded) {
 			spellCooldown -= getWheelOfDestinyBoost(WheelSpellBoost_t::COOLDOWN, spellGrade);
 		}
-		int32_t augmentCooldownReduction = calculateAugmentSpellCooldownReduction(player);
 		g_logger().debug("[{}] spell name: {}, spellCooldown: {}, bonus: {}, augment {}", __FUNCTION__, name, spellCooldown, player->wheel()->getSpellBonus(name, WheelSpellBoost_t::COOLDOWN), augmentCooldownReduction);
 		spellCooldown -= player->wheel()->getSpellBonus(name, WheelSpellBoost_t::COOLDOWN);
 		spellCooldown -= augmentCooldownReduction;
@@ -809,6 +808,7 @@ void Spell::applyCooldownConditions(const std::shared_ptr<Player> &player) const
 			spellSecondaryGroupCooldown -= getWheelOfDestinyBoost(WheelSpellBoost_t::SECONDARY_GROUP_COOLDOWN, spellGrade);
 		}
 		spellSecondaryGroupCooldown -= player->wheel()->getSpellBonus(name, WheelSpellBoost_t::SECONDARY_GROUP_COOLDOWN);
+		spellSecondaryGroupCooldown -= augmentCooldownReduction;
 		// Vocation Adjustment: Focus Mastery additionally reduces the focus-spell group cooldown by 2s.
 		if (secondaryGroup == SPELLGROUP_FOCUS && player->wheel()->getInstant("Focus Mastery")) {
 			spellSecondaryGroupCooldown -= 2000;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -12903,7 +12903,7 @@ void Player::applyEquippedWeaponProficiency(const uint16_t itemId) {
 				continue;
 			}
 
-			if (perk.perkValue < 0.0f) {
+			if (perk.perkValue < 0.0f && perk.perkType != PROFICIENCY_PERK_AUGMENT_TYPE) {
 				continue;
 			}
 


### PR DESCRIPTION
## TLDR
The weapon proficiency system loads its data from `proficiencies.json`, where cooldown reduction values are stored as **negative** numbers (ex. `-6.0`). However, part of the codebase was written to discard any perk with a negative value, and another part didn't account for the negative sign or the unit (seconds vs. milliseconds) when applying it. As a result, the cooldown reduction perk:

- was discarded before it was even processed (`player.cpp`);
- was applied with the wrong unit and sign when it was processed (`spells.cpp`, primary cooldown);
- was never applied at all to the "special cooldown" / secondary group cooldown (`spells.cpp`, `secondaryGroupCooldown`).

I tested the changes and it seemed to resolve perfectly.
---
<details>
<summary> player.cpp </summary>

`Player::applyEquippedWeaponProficiency()`

A generic filter discarded any perk with a negative value before it ever reached the logic that builds `spellAugments`. Since cooldown reduction perks are stored as negative values by design, this perk was never processed at all.

**Before:**
```cpp
if (perk.perkValue < 0.0f) {
    continue;
}
```

**After:**
```cpp
if (perk.perkValue < 0.0f && perk.perkType != PROFICIENCY_PERK_AUGMENT_TYPE) {
    continue;
}
```
</details>

---

<details>
<summary>  spells.cpp </summary>

`Spell::calculateAugmentSpellCooldownReduction()`

The perk value was applied directly to the cooldown without converting seconds to milliseconds, and without compensating for the negative sign used to represent a reduction.

**Before:**
```cpp
const int32_t augmentValue = playerProficiencyAugment.value * 1;
```

**After:**
```cpp
const int32_t augmentValue = static_cast<int32_t>(playerProficiencyAugment.value * -1000.0f);
```

---

`Spell::applyCooldownConditions()`

The `augmentCooldownReduction` variable was declared **inside** the `if (cooldown > 0) { ... }` block, so it didn't exist (local scope) for the `groupCooldown` and `secondaryGroupCooldown` blocks to use.

**Before:**
```cpp
if (cooldown > 0) {
    int32_t spellCooldown = cooldown;
    ...
    int32_t augmentCooldownReduction = calculateAugmentSpellCooldownReduction(player); // only exists in here
    ...
    spellCooldown -= augmentCooldownReduction;
}
```

**After:**
```cpp
int32_t augmentCooldownReduction = calculateAugmentSpellCooldownReduction(player); // moved to the top of the function
if (cooldown > 0) {
    int32_t spellCooldown = cooldown;
    ...
    spellCooldown -= augmentCooldownReduction;
}
```

By moving the declaration above all three `if` blocks (`cooldown`, `groupCooldown`, `secondaryGroupCooldown`), the value computed once becomes visible to all of them.

The block handling `secondaryGroupCooldown` ("special cooldown") never applied the weapon proficiency reduction at all. It only applied the fixed "Focus Mastery" talent bonus.

**Before:**
```cpp
if (secondaryGroupCooldown > 0) {
    int32_t spellSecondaryGroupCooldown = secondaryGroupCooldown;
    if (isUpgraded) {
        spellSecondaryGroupCooldown -= getWheelOfDestinyBoost(WheelSpellBoost_t::SECONDARY_GROUP_COOLDOWN, spellGrade);
    }
    spellSecondaryGroupCooldown -= player->wheel()->getSpellBonus(name, WheelSpellBoost_t::SECONDARY_GROUP_COOLDOWN);
    // Vocation Adjustment: Focus Mastery additionally reduces the focus-spell group cooldown by 2s.
    if (secondaryGroup == SPELLGROUP_FOCUS && player->wheel()->getInstant("Focus Mastery")) {
        spellSecondaryGroupCooldown -= 2000;
    }
    if (spellSecondaryGroupCooldown > 0) {
        player->wheel()->handleBeamMasteryCooldown(player, name, spellSecondaryGroupCooldown, rateCooldown);
        const auto &condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, spellSecondaryGroupCooldown / rateCooldown, 0, false, secondaryGroup);
        player->addCondition(condition);
    }
}
```

**After:**
```cpp
if (secondaryGroupCooldown > 0) {
    int32_t spellSecondaryGroupCooldown = secondaryGroupCooldown;
    if (isUpgraded) {
        spellSecondaryGroupCooldown -= getWheelOfDestinyBoost(WheelSpellBoost_t::SECONDARY_GROUP_COOLDOWN, spellGrade);
    }
    spellSecondaryGroupCooldown -= player->wheel()->getSpellBonus(name, WheelSpellBoost_t::SECONDARY_GROUP_COOLDOWN);
    spellSecondaryGroupCooldown -= augmentCooldownReduction;
    // Vocation Adjustment: Focus Mastery additionally reduces the focus-spell group cooldown by 2s.
    if (secondaryGroup == SPELLGROUP_FOCUS && player->wheel()->getInstant("Focus Mastery")) {
        spellSecondaryGroupCooldown -= 2000;
    }
    if (spellSecondaryGroupCooldown > 0) {
        player->wheel()->handleBeamMasteryCooldown(player, name, spellSecondaryGroupCooldown, rateCooldown);
        const auto &condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, spellSecondaryGroupCooldown / rateCooldown, 0, false, secondaryGroup);
        player->addCondition(condition);
    }
}
```
</details>