### PR TITLE
fix(protocol): prevent bestiary request dispatcher stall

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -3250,9 +3250,22 @@ void ProtocolGame::parseBestiarySendCreatures(NetworkMessage &msg) {
 	uint8_t search = msg.getByte();
 
 	if (search == 1) {
-		auto monsterAmount = msg.get<uint16_t>();
-		std::map<uint16_t, std::string> mtype_list = g_game().getBestiaryList();
-		for (uint16_t monsterCount = 1; monsterCount <= monsterAmount; monsterCount++) {
+		if (!msg.canRead(sizeof(uint16_t))) {
+			return;
+		}
+
+		const auto monsterAmount = msg.get<uint16_t>();
+		const auto raceIdsSize = static_cast<int32_t>(monsterAmount) * static_cast<int32_t>(sizeof(uint16_t));
+		if (!msg.canRead(raceIdsSize)) {
+			return;
+		}
+
+		const auto mtype_list = g_game().getBestiaryList();
+		if (monsterAmount > mtype_list.size()) {
+			return;
+		}
+
+		for (uint32_t monsterCount = 0; monsterCount < monsterAmount; ++monsterCount) {
 			auto raceid = msg.get<uint16_t>();
 			if (player->getBestiaryKillCount(raceid) > 0) {
 				auto it = mtype_list.find(raceid);


### PR DESCRIPTION
Reject malformed creature counts when the packet does not contain the declared race IDs or exceeds the server bestiary size.

Use a zero-based 32-bit loop counter so the maximum uint16 value cannot wrap and monopolize the serial dispatcher.