### PR TITLE
Add missing items.xml entry for primal pod (id 39176)

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -71944,6 +71944,7 @@
 	<item id="39168" article="a" name="heated crystal" />
 	<item id="39169" article="a" name="cooled crystal" />
 	<item fromid="39173" toid="39175" article="a" name="blessed pound" />
+	<item id="39176" article="a" name="primal pod" />
 	<item id="39177" article="a" name="charged spiritthorn ring">
 		<attribute key="primarytype" value="rings" />
 		<attribute key="transformEquipTo" value="39178" />


### PR DESCRIPTION
## Description

Item id **39176** (primal pod, used by the Gnomprona hazard system via `ITEM_PRIMAL_POD` in `src/utils/utils_definitions.hpp` and `data-global/scripts/systems/hazard_primal.lua`) has no entry in `data/items/items.xml` — the id range jumps from 39173-39175 (blessed pound) straight to 39177 (charged spiritthorn ring).

The appearance for 39176 exists in `data/items/appearances.dat`, so the item works at runtime (pods spawn and step events fire), but:
- Looking at a pod shows a nameless item instead of "You see a primal pod."
- `Items::getItemIdByName("primal pod")` returns 0 because `nameToItems` never gets the name registered.

This PR adds the missing one-line entry:

```xml
<item id="39176" article="a" name="primal pod" />
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)