### PR TITLE
fix: Energuardian of Tales missing Inkborn bestiary class

### DIFF
--- a/data-crystal/monster/magicals/energuardian_of_tales.lua
+++ b/data-crystal/monster/magicals/energuardian_of_tales.lua
@@ -15,8 +15,8 @@ monster.outfit = {
 
 monster.raceId = 1666
 monster.Bestiary = {
-	class = "Magical",
-	race = BESTY_RACE_MAGICAL,
+	class = "Inkborn",
+	race = BESTY_RACE_INKBORN,
 	toKill = 2500,
 	FirstUnlock = 100,
 	SecondUnlock = 1000,

--- a/data-global/monster/magicals/energuardian_of_tales.lua
+++ b/data-global/monster/magicals/energuardian_of_tales.lua
@@ -15,8 +15,8 @@ monster.outfit = {
 
 monster.raceId = 1666
 monster.Bestiary = {
-	class = "Magical",
-	race = BESTY_RACE_MAGICAL,
+	class = "Inkborn",
+	race = BESTY_RACE_INKBORN,
 	toKill = 2500,
 	FirstUnlock = 100,
 	SecondUnlock = 1000,


### PR DESCRIPTION
### What

Sets `class = "Inkborn"` / `race = BESTY_RACE_INKBORN` for **Energuardian of Tales** (raceId 1666) in both `data-global` and `data-crystal`.

### Why

#640 ("feat: Bestiary Inkborn added") moved the whole Secret Library creature set to the Inkborn bestiary class, but this one file was skipped. It is still `Magical`, while its direct counterpart *Guardian of Tales* and the rest of the set — Flying Book, Biting Book, Ink Blob, Animated Feather, Burning/Cursed/Energetic/Icecold Book, Brain Squid, Rage Squid, Squid Warden — are already `Inkborn`.

In game the creature belongs to the Inkborn class, so right now the Cyclopedia lists it under the wrong category and it is not counted towards the "Inkslayer" title (unlock all Inkborn Bestiary entries).

**Source:** https://tibiopedia.pl/monsters/inkborn — the Inkborn ("Atramentowe") bestiary listing includes Energuardian of Tales (11361 exp, 14000 HP, 50 charm points), together with the 21 creatures this repository already classifies as Inkborn.

The file stays in `monster/magicals/`, consistent with how #640 handled the other reclassified creatures (only the newly added ones went into `monster/inkborn/`).

### How to test

1. Start the server.
2. Open Cyclopedia -> Bestiary -> Inkborn.
3. Energuardian of Tales is listed there instead of under Magical.
