### PR TITLE
fix:  Tile::addThing ground-replacement captures a reference to the `ground` member instead of a copy

### DIFF
--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1068,7 +1068,7 @@ void Tile::addThing(int32_t, const std::shared_ptr<Thing> &thing) {
 			} else {
 				const ItemType &oldType = Item::items[ground->getID()];
 
-				const auto &oldGround = ground;
+				const auto oldGround = ground;
 				ground->resetParent();
 				ground = item;
 				resetTileFlags(oldGround);


### PR DESCRIPTION
The Tile::addThing ground-replacement captures a reference to the `ground` member instead of a copy, corrupting old/new item handling

**How to.** On a tile that already has a ground item, add a second ground-type item via Tile::addThing (e.g. map edit, moveItem of a ground tile, or a script placing ground). The old ground's tile flags are never reset, so pathfinding/collision can desync (e.g. a now-walkable tile still flagged BLOCKPATH, or vice-versa), and the client receives a remove notification for the wrong item.
