### PR TITLE
fix: Grimvale spectator teleport event handling

### DIFF
--- a/data-global/lib/quests/grimvale.lua
+++ b/data-global/lib/quests/grimvale.lua
@@ -76,9 +76,9 @@ function grimvaleSpectators()
 	for i = 1, #specs do
 		spec = specs[i]
 		if spec and spec:isPlayer() then
-			oldpos = spec:getPosition()
+			local oldpos = spec:getPosition()
+			addEvent(teleportPlayer, 60 * 1000, spec:getId(), oldpos)
 		end
-		addEvent(teleportPlayer, 1, 60 * 1000, spec:getId(), oldpos)
 	end
 	if Game.getStorageValue(GlobalStorage.Feroxa.Active) == 2 then
 		addEvent(removeItems, 15 * 60 * 1000)


### PR DESCRIPTION
Move the addEvent call inside the player validity check to ensure the teleport event is only scheduled for valid players. 
Make oldpos a local variable to avoid scope pollution. 
Also fixes incorrect addEvent parameter order by removing erroneous first argument.

How to reproduce:
Trigger the grimvale full-moon world change and observe that spectators are not teleported after the phase; teleportPlayer runs with playerId 60000.
