### PR TITLE
fix: Prevent duplicate raid spawns using executedRaids

### DIFF
--- a/data-global/scripts/globalevents/others/raids_schedule.lua
+++ b/data-global/scripts/globalevents/others/raids_schedule.lua
@@ -24,6 +24,7 @@ local raidSchedule = {
 }
 
 local spawnRaidsEvent = GlobalEvent("SpawnRaidsEvent")
+local executedRaids = {}
 
 function spawnRaidsEvent.onThink(interval, lastExecution, thinkInterval)
 	local currentDayOfWeek, currentDate = os.date("%A"), getRealDate()
@@ -40,9 +41,12 @@ function spawnRaidsEvent.onThink(interval, lastExecution, thinkInterval)
 	if #raidsToSpawn > 0 then
 		for i = 1, #raidsToSpawn do
 			local currentRaidSchedule = raidsToSpawn[i][getRealTime()]
-			if currentRaidSchedule and not currentRaidSchedule.alreadyExecuted then
-				Game.startRaid(currentRaidSchedule.raidName)
-				currentRaidSchedule.alreadyExecuted = true
+			if currentRaidSchedule then
+				local raidKey = currentDate .. "|" .. getRealTime() .. "|" .. currentRaidSchedule.raidName
+				if not executedRaids[raidKey] then
+					Game.startRaid(currentRaidSchedule.raidName)
+					executedRaids[raidKey] = true
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Add a local executedRaids table and use a composite raidKey (date|time|raidName) in spawnRaidsEvent.onThink to ensure each scheduled raid is started only once. This replaces the previous per-schedule alreadyExecuted flag by checking and marking executedRaids[raidKey] when Game.startRaid is called.