### PR TITLE
fix: Prevent nil attacker crash in SoulCage health

### DIFF
--- a/data-global/scripts/quests/soul_war/soul_war_mechanics.lua
+++ b/data-global/scripts/quests/soul_war/soul_war_mechanics.lua
@@ -35,6 +35,10 @@ goshnarsMaliceReflection:register()
 local soulCageReflection = CreatureEvent("SoulCageHealthChange")
 
 function soulCageReflection.onHealthChange(creature, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
+	if not attacker then
+		return primaryDamage, primaryType, secondaryDamage, secondaryType
+	end
+
 	local player = attacker:getPlayer()
 	if player then
 		if primaryDamage > 0 then


### PR DESCRIPTION
Add an early nil-check for attacker in soulCageReflection.onHealthChange to avoid runtime errors when the health change is triggered without an attacker. The handler now returns the original damage/type values unchanged if attacker is nil.