### PR TITLE
fix: Agony damage case in DamageToConditionType

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -332,7 +332,7 @@ ConditionType_t Combat::DamageToConditionType(CombatType_t type) {
 		case COMBAT_EARTHDAMAGE:
 			return CONDITION_POISON;
 
-		case CONDITION_AGONY:
+		case COMBAT_AGONYDAMAGE:
 			return CONDITION_AGONY;
 
 		case COMBAT_ICEDAMAGE:


### PR DESCRIPTION
Replace erroneous CONDITION_AGONY case with COMBAT_AGONYDAMAGE in DamageToConditionType so agony combat damage correctly maps to CONDITION_AGONY.