### PR TITLE
fix: Guard divide-by-zero in player exp rate

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3601,7 +3601,7 @@ void Player::addExperience(const std::shared_ptr<Creature> &target, uint64_t exp
 		return;
 	}
 
-	const auto rate = exp / rawExp;
+	const auto rate = rawExp != 0 ? exp / rawExp : 1;
 	const std::map<std::string, std::string> attrs({ { "player", getName() }, { "level", std::to_string(getLevel()) }, { "rate", std::to_string(rate) } });
 	if (sendText) {
 		g_metrics().addCounter("player_experience_raw", rawExp, attrs);


### PR DESCRIPTION
Prevent a division-by-zero when computing the experience rate in Player::addExperience. Uses a conditional to set rate = exp/rawExp when rawExp != 0, otherwise defaults rate to 1. This avoids undefined behavior/crashes when rawExp is zero and preserves existing metrics logging.