### PR TITLE
fix: Stash withdraw removes from stash before placement, shortfall silently destroyed (item loss)

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -9234,6 +9234,7 @@ ReturnValue Player::addItemFromStash(uint16_t itemId, uint32_t itemCount) {
 	}
 
 	uint32_t addedItemCount = 0;
+	uint32_t totalWithdrawn = finalRetrievable;
 	uint32_t remainingToRetrieve = finalRetrievable;
 
 	if (itemType.stackable) {
@@ -9334,6 +9335,13 @@ ReturnValue Player::addItemFromStash(uint16_t itemId, uint32_t itemCount) {
 				++cacheIndex;
 			}
 		}
+	}
+
+	// Refund unplaced items back to stash
+	if (addedItemCount < totalWithdrawn) {
+		uint32_t unplaced = totalWithdrawn - addedItemCount;
+		stashItems[itemId] += unplaced;
+		g_logger().warn("[addItemFromStash] Refunded {}x itemId: {} back to stash for player {}", unplaced, itemId, getName());
 	}
 
 	std::string itemName = itemType.name + (addedItemCount > 1 ? "s" : "");

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -9250,6 +9250,11 @@ ReturnValue Player::addItemFromStash(uint16_t itemId, uint32_t itemCount) {
 					break;
 				}
 
+				if (!stackableItem || !stackableItem->getParent()) {
+					it = stackableItemsCache.erase(it);
+					continue;
+				}
+
 				uint32_t spaceInStack = stackableItem->getStackSize() - stackableItem->getItemCount();
 				uint32_t stackableCount = std::min(spaceInStack, addValue);
 


### PR DESCRIPTION
### How to reproduce:
Stash a large count of a heavy/awkward-to-place stackable, arrange a near-full backpack layout so the slot estimate overcounts, withdraw the max; observe 'Retrieved Nx' with N < withdrawn and the missing count gone from both stash and inventory.

### Solution
Refund the unplaced remainder (finalRetrievable - addedItemCount) back into stashItems before returning, in every early-break path.