### PR TITLE
fix: Underflow in wheel points calculation

### DIFF
--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -2063,7 +2063,8 @@ void PlayerWheel::addExtraPointsFromHuntingTaskShop(uint16_t amount) {
 
 uint16_t PlayerWheel::getWheelPoints(bool includeExtraPoints /* = true*/) const {
 	const uint32_t level = m_player.getLevel();
-	auto totalPoints = std::max(0u, (level - m_minLevelToStartCountPoints)) * m_pointsPerLevel;
+	const uint32_t effLevel = level > m_minLevelToStartCountPoints ? level - m_minLevelToStartCountPoints : 0;
+	uint32_t totalPoints = effLevel * m_pointsPerLevel;
 
 	if (includeExtraPoints) {
 		totalPoints += getExtraPoints();


### PR DESCRIPTION
Prevent unsigned underflow when player's level is below the minimum. The previous expression subtracted two unsigned values before std::max, which could wrap and yield incorrect large point totals. Compute an effective level with a conditional (0 if below minimum) and use uint32_t for totalPoints. Function behavior otherwise unchanged; extra points are still added when included.