### PR TITLE
fix: Prevent reads on closed sockets; handle XTEA fail

### DIFF
--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -299,6 +299,11 @@ void Connection::parsePacket(const std::error_code &error) {
 		skipReadingNextPacket = protocol->onRecvMessage(m_msg);
 	}
 
+	// Protocol may have closed us (e.g. XTEA fail) — do not rearm timers/reads.
+	if (connectionState == CONNECTION_STATE_CLOSED || !socket.is_open()) {
+		return;
+	}
+
 	try {
 		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait([self = std::weak_ptr<Connection>(shared_from_this())](const std::error_code &error) { Connection::handleTimeout(self, error); });
@@ -314,10 +319,17 @@ void Connection::parsePacket(const std::error_code &error) {
 }
 
 void Connection::resumeWork() {
-	readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
-	readTimer.async_wait([self = std::weak_ptr<Connection>(shared_from_this())](const std::error_code &error) { Connection::handleTimeout(self, error); });
+	// Dispatcher may run a previously queued sendRecv callback after the peer
+	// already dropped (XTEA fail / Broken pipe). Never arm ASIO reads on a dead socket.
+	std::scoped_lock lock(connectionLock);
+	if (connectionState == CONNECTION_STATE_CLOSED || !socket.is_open()) {
+		return;
+	}
 
 	try {
+		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.async_wait([self = std::weak_ptr<Connection>(shared_from_this())](const std::error_code &error) { Connection::handleTimeout(self, error); });
+
 		asio::async_read(socket, asio::buffer(m_msg.getBuffer(), HEADER_LENGTH), [self = shared_from_this()](const std::error_code &error, std::size_t N) { self->parseHeader(error); });
 	} catch (const std::system_error &e) {
 		g_logger().error("[Connection::resumeWork] - Exception in async_read: {}", e.what());

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -54,8 +54,16 @@ void Protocol::onSendMessage(const OutputMessage_ptr &msg) {
 
 bool Protocol::sendRecvMessageCallback(NetworkMessage &msg) {
 	if (encryptionEnabled && !XTEA_decrypt(msg)) {
-		g_logger().error("[Protocol::onRecvMessage] - XTEA_decrypt Failed");
-		return false;
+		if (const auto &connection = getConnection()) {
+			g_logger().error(
+				"[Protocol::onRecvMessage] - XTEA_decrypt Failed, IP: {}",
+				convertIPToString(connection->getIP())
+			);
+			connection->close(FORCE_CLOSE);
+		} else {
+			g_logger().error("[Protocol::onRecvMessage] - XTEA_decrypt Failed");
+		}
+		return true;
 	}
 
 	g_dispatcher().addEvent(


### PR DESCRIPTION
Add safety checks to avoid rearming ASIO timers/reads on closed connections. Connection::parsePacket and resumeWork now bail out if connectionState is CLOSED or socket is not open; resumeWork also takes connectionLock to avoid races. Protocol::sendRecvMessageCallback logs the peer IP on XTEA_decrypt failure and force-closes the connection, returning true to stop further processing. These changes prevent use-after-close/broken-pipe errors when decryption or remote disconnects occur.