### PR TITLE
fix: Report storeQuery success correctly

### DIFF
--- a/src/database/databasetasks.cpp
+++ b/src/database/databasetasks.cpp
@@ -42,7 +42,7 @@ void DatabaseTasks::store(const std::string &query, const std::function<void(DBR
 	threadPool.detach_task([this, query, callback]() {
 		DBResult_ptr result = db.storeQuery(query);
 		if (callback != nullptr) {
-			g_dispatcher().addEvent([callback, result]() { callback(result, true); }, __FUNCTION__);
+			g_dispatcher().addEvent([callback, result]() { callback(result, result != nullptr); }, __FUNCTION__);
 		}
 	});
 }


### PR DESCRIPTION
Previously the store callback always received true regardless of the db.storeQuery result. Change passes result != nullptr so the callback receives an accurate success flag.