### PR TITLE
fix: itemsClassifications memory leak

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9033,16 +9033,17 @@ void Game::checkLight() {
 }
 
 ItemClassification* Game::getItemsClassification(uint8_t id, bool create) {
-	auto it = std::ranges::find_if(itemsClassifications, [id](ItemClassification* classification) {
+	auto it = std::ranges::find_if(itemsClassifications, [id](const std::unique_ptr<ItemClassification> &classification) {
 		return classification->id == id;
 	});
 
 	if (it != itemsClassifications.end()) {
-		return *it;
+		return it->get();
 	} else if (create) {
-		auto itemClassification = new ItemClassification(id);
-		addItemsClassification(itemClassification);
-		return itemClassification;
+		auto itemClassification = std::make_unique<ItemClassification>(id);
+		auto* raw = itemClassification.get();
+		addItemsClassification(std::move(itemClassification));
+		return raw;
 	}
 
 	return nullptr;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -27,6 +27,7 @@
 #include "modal_window/modal_window.hpp"
 #include "movement/position.hpp"
 #include "creatures/creatures_definitions.hpp"
+#include "items/items_classification.hpp"
 
 // Forward declaration for protobuf class
 namespace Crystal {
@@ -44,7 +45,6 @@ class Npc;
 class Charm;
 class IOPrey;
 class IOWheel;
-class ItemClassification;
 class Guild;
 class Mounts;
 class AttachedEffects;
@@ -220,8 +220,8 @@ public:
 	bool isSwimmingPool(const std::shared_ptr<Item> &item, const std::shared_ptr<Tile> &tile, bool checkProtection) const;
 	void createIllusion(const std::shared_ptr<Player> &player, const Outfit_t &outfit, int32_t time);
 
-	void addItemsClassification(ItemClassification* itemsClassification) {
-		itemsClassifications.push_back(itemsClassification);
+	void addItemsClassification(std::unique_ptr<ItemClassification> itemsClassification) {
+		itemsClassifications.push_back(std::move(itemsClassification));
 	}
 	ItemClassification* getItemsClassification(uint8_t id, bool create);
 
@@ -621,8 +621,13 @@ public:
 	void removeDeadPlayer(const std::string &playerName);
 	std::shared_ptr<Player> getDeadPlayer(const std::string &playerName);
 
-	const std::vector<ItemClassification*> &getItemsClassifications() const {
-		return itemsClassifications;
+	std::vector<ItemClassification*> getItemsClassifications() const {
+		std::vector<ItemClassification*> result;
+		result.reserve(itemsClassifications.size());
+		for (const auto &ptr : itemsClassifications) {
+			result.push_back(ptr.get());
+		}
+		return result;
 	}
 
 	void addPlayer(const std::shared_ptr<Player> &player);
@@ -972,7 +977,7 @@ private:
 
 	std::map<uint16_t, std::map<uint8_t, uint64_t>> itemsPriceMap;
 
-	std::vector<ItemClassification*> itemsClassifications;
+	std::vector<std::unique_ptr<ItemClassification>> itemsClassifications;
 
 	bool isTryingToStow(const Position &toPos, const std::shared_ptr<Cylinder> &toCylinder) const;
 


### PR DESCRIPTION


Migrate itemsClassifications to std::vector<std::unique_ptr<ItemClassification>> and include items_classification.hpp. addItemsClassification now accepts a std::unique_ptr and items are moved into the container. getItemsClassification uses std::ranges::find_if over unique_ptrs and returns a raw pointer; when creating a new classification it constructs a unique_ptr, moves it into the vector and returns the raw pointer. getItemsClassifications now returns a vector of raw pointers (copied) instead of a const ref. Purpose: improve ownership, RAII and prevent leaks. Note: callers must be updated to pass/move unique_ptrs and adapt to the new getter return.