### PR TITLE
fix: Use atomic operations for task ID generation

### DIFF
--- a/src/game/scheduling/task.hpp
+++ b/src/game/scheduling/task.hpp
@@ -29,10 +29,11 @@ public:
 
 	uint64_t getId() {
 		if (id == 0) {
-			if (++LAST_EVENT_ID == 0) {
-				LAST_EVENT_ID = 1;
+			uint64_t newId = LAST_EVENT_ID.fetch_add(1, std::memory_order_relaxed) + 1;
+			if (newId == 0) {
+				newId = LAST_EVENT_ID.fetch_add(1, std::memory_order_relaxed) + 1;
 			}
-			id = LAST_EVENT_ID;
+			id = newId;
 		}
 		return id;
 	}


### PR DESCRIPTION
Replace direct increment operations on LAST_EVENT_ID with proper atomic fetch_add() calls using memory_order_relaxed. This ensures thread-safe ID generation and correct handling of ID wraparound to zero, improving the reliability of event ID assignment in the task scheduling system.