### PR TITLE
fix: Resend player map description on map load

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -8413,6 +8413,12 @@ void Player::sendEnterWorld() const {
 	}
 }
 
+void Player::sendMapDescription(const Position &pos) const {
+	if (client) {
+		client->sendMapDescription(pos);
+	}
+}
+
 void Player::sendFightModes() const {
 	if (client) {
 		client->sendFightModes();

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1169,6 +1169,7 @@ public:
 	bool hasAsyncOngoingTask(uint64_t flags) const;
 	void resetAsyncOngoingTask(uint64_t flags);
 	void sendEnterWorld() const;
+	void sendMapDescription(const Position &pos) const;
 	void sendFightModes() const;
 	void sendNetworkMessage(NetworkMessage &message) const;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -824,6 +824,14 @@ void Game::loadCustomMaps(const std::filesystem::path &customMapPath) {
 void Game::loadMap(const std::string &path, const Position &pos) {
 	lastMapLoadTime = OTSYS_TIME();
 	map.loadMap(path, false, false, false, false, false, pos);
+
+	// Resend the viewport to all connected players so the client does not
+	// retain stale tile references after a map swap (e.g. quest map changes).
+	for (const auto &[playerId, player] : players) {
+		if (player) {
+			player->sendMapDescription(player->getPosition());
+		}
+	}
 }
 
 std::shared_ptr<Cylinder> Game::internalGetCylinder(const std::shared_ptr<Player> &player, const Position &pos) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -825,12 +825,49 @@ void Game::loadMap(const std::string &path, const Position &pos) {
 	lastMapLoadTime = OTSYS_TIME();
 	map.loadMap(path, false, false, false, false, false, pos);
 
-	// Resend the viewport to all connected players so the client does not
-	// retain stale tile references after a map swap (e.g. quest map changes).
+	const auto &area = map.getLastLoadedArea();
+	if (!area.valid) {
+		return;
+	}
+
+	// The client draws neighbouring floors shifted on x/y, so pad the box by
+	// the viewport plus the maximum floor shift.
+	constexpr int32_t paddingX = MAP_MAX_CLIENT_VIEW_PORT_X + 1 + MAP_MAX_LAYERS;
+	constexpr int32_t paddingY = MAP_MAX_CLIENT_VIEW_PORT_Y + 1 + MAP_MAX_LAYERS;
+
 	for (const auto &[playerId, player] : players) {
-		if (player) {
-			player->sendMapDescription(player->getPosition());
+		if (!player) {
+			continue;
 		}
+
+		const Position &playerPos = player->getPosition();
+		const auto posX = static_cast<int32_t>(playerPos.x);
+		const auto posY = static_cast<int32_t>(playerPos.y);
+		const auto posZ = static_cast<int32_t>(playerPos.z);
+
+		if (posX < area.minX - paddingX || posX > area.maxX + paddingX) {
+			continue;
+		}
+
+		if (posY < area.minY - paddingY || posY > area.maxY + paddingY) {
+			continue;
+		}
+
+		// Same floor range ProtocolGame::GetMapDescription walks through.
+		int32_t visibleMinZ, visibleMaxZ;
+		if (posZ > MAP_INIT_SURFACE_LAYER) {
+			visibleMinZ = posZ - MAP_LAYER_VIEW_LIMIT;
+			visibleMaxZ = std::min<int32_t>(MAP_MAX_LAYERS - 1, posZ + MAP_LAYER_VIEW_LIMIT);
+		} else {
+			visibleMinZ = 0;
+			visibleMaxZ = MAP_INIT_SURFACE_LAYER;
+		}
+
+		if (area.maxZ < visibleMinZ || area.minZ > visibleMaxZ) {
+			continue;
+		}
+
+		player->sendMapDescription(playerPos);
 	}
 }
 

--- a/src/io/iomap.cpp
+++ b/src/io/iomap.cpp
@@ -150,6 +150,9 @@ void IOMap::loadMap(Map* map, const Position &pos) {
 		throw IOMapException("This map need to be upgraded by using the latest map editor version to be able to load correctly.");
 	}
 
+	// Reset before parsing so the bounds always describe this load only.
+	map->lastLoadedArea = {};
+
 	if (stream.startNode(OTBM_MAP_DATA)) {
 		parseMapDataAttributes(stream, map);
 		parseTileArea(stream, *map, pos);
@@ -220,6 +223,23 @@ void IOMap::parseTileArea(FileStream &stream, Map &map, const Position &pos) {
 			const uint16_t x = base_x + tileCoordsX + pos.x;
 			const uint16_t y = base_y + tileCoordsY + pos.y;
 			const auto z = static_cast<uint8_t>(base_z + pos.z);
+
+			// Bounds are kept in int32_t so callers can pad them by the client
+			// viewport without wrapping around near the map edges.
+			auto &area = map.lastLoadedArea;
+			if (!area.valid) {
+				area.valid = true;
+				area.minX = area.maxX = x;
+				area.minY = area.maxY = y;
+				area.minZ = area.maxZ = z;
+			} else {
+				area.minX = std::min<int32_t>(area.minX, x);
+				area.maxX = std::max<int32_t>(area.maxX, x);
+				area.minY = std::min<int32_t>(area.minY, y);
+				area.maxY = std::max<int32_t>(area.maxY, y);
+				area.minZ = std::min<int32_t>(area.minZ, z);
+				area.maxZ = std::max<int32_t>(area.maxZ, z);
+			}
 
 			if (tileType == OTBM_HOUSETILE) {
 				tile->houseId = stream.getU32();

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -46,6 +46,25 @@ public:
 	}
 
 	/**
+	 * Axis aligned bounding box of every tile touched by the last load().
+	 * Lets the caller refresh only the players that can actually see the
+	 * swapped tiles instead of every player online.
+	 */
+	struct LoadedArea {
+		bool valid = false;
+		int32_t minX = 0;
+		int32_t minY = 0;
+		int32_t minZ = 0;
+		int32_t maxX = 0;
+		int32_t maxY = 0;
+		int32_t maxZ = 0;
+	};
+
+	const LoadedArea &getLastLoadedArea() const {
+		return lastLoadedArea;
+	}
+
+	/**
 	 * Load a map.
 	 * \returns true if the map was loaded successfully
 	 */
@@ -169,6 +188,8 @@ private:
 
 	uint32_t width = 0;
 	uint32_t height = 0;
+
+	LoadedArea lastLoadedArea;
 
 	friend class Game;
 	friend class IOMap;


### PR DESCRIPTION
After loading a new map, iterate connected players and resend their map description to refresh client view and avoid stale tile references after map swaps (e.g. quest map changes).

Fixes https://github.com/zimbadev/crystalserver/issues/852

NOTE: This isn't the best solution, as it reloads all the online players, but for now, it was the best option; we are analyzing the situation to find another solution.