### PR TITLE
fix: Spawn removal and Optimize creature checks

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1128,6 +1128,7 @@ void Monster::onThink(uint32_t interval) {
 
 	if (!mType->canSpawn(position)) {
 		g_game().removeCreature(static_self_cast<Monster>());
+		return;
 	}
 
 	if (!isInSpawnRange(position)) {

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -344,6 +344,7 @@ void Npc::onThink(uint32_t interval) {
 
 	if (!npcType->canSpawn(position)) {
 		g_game().removeCreature(static_self_cast<Npc>());
+		return;
 	}
 
 	if (!isInSpawnRange(position)) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -88,7 +88,7 @@
 #include <appearances.pb.h>
 
 std::vector<std::weak_ptr<Creature>> checkCreatureLists[EVENT_CREATURECOUNT];
-size_t checkCreatureSizes[EVENT_CREATURECOUNT] = {};  // Track sizes for reserve
+size_t checkCreatureSizes[EVENT_CREATURECOUNT] = {}; // Track sizes for reserve
 
 namespace {
 	bool isBountyHighscoreCategory(const std::string &categoryName) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -88,6 +88,7 @@
 #include <appearances.pb.h>
 
 std::vector<std::weak_ptr<Creature>> checkCreatureLists[EVENT_CREATURECOUNT];
+size_t checkCreatureSizes[EVENT_CREATURECOUNT] = {};  // Track sizes for reserve
 
 namespace {
 	bool isBountyHighscoreCategory(const std::string &categoryName) {
@@ -6959,7 +6960,12 @@ void Game::addCreatureCheck(const std::shared_ptr<Creature> &creature) {
 	}
 
 	g_dispatcher().addEvent([this, index = uniform_random(0, EVENT_CREATURECOUNT - 1), creature] {
+		// Reserve capacity to avoid frequent reallocations
+		if (checkCreatureLists[index].capacity() <= checkCreatureLists[index].size()) {
+			checkCreatureLists[index].reserve(checkCreatureLists[index].size() + 32);
+		}
 		checkCreatureLists[index].emplace_back(creature);
+		checkCreatureSizes[index]++;
 	},
 	                        "Game::addCreatureCheck");
 }
@@ -6975,13 +6981,23 @@ void Game::checkCreatures() {
 	metrics::method_latency measure(__METRICS_METHOD_NAME__);
 	static size_t index = 0;
 
-	std::erase_if(checkCreatureLists[index], [this](const std::weak_ptr<Creature> &weak) {
+	auto &bucket = checkCreatureLists[index];
+
+	// Skip empty buckets early
+	if (bucket.empty()) {
+		index = (index + 1) % EVENT_CREATURECOUNT;
+		return;
+	}
+
+	// Manual loop for better control and tracking
+	size_t writeIndex = 0;
+	for (size_t i = 0; i < bucket.size(); ++i) {
+		const auto &weak = bucket[i];
 		if (const auto creature = weak.lock()) {
 			if (creature->creatureCheck && creature->isAlive()) {
 				creature->onThink(EVENT_CREATURE_THINK_INTERVAL);
 				if (creature->getMonster()) {
-					// The monster's onThink function runs asynchronously,
-					// meaning the target gets updated at a later time; therefore, we must delay the actions outlined below.
+					// Monster's onThink runs asynchronously, so delay attacking/conditions
 					g_dispatcher().addEvent([creature] {
 						if (creature->isAlive()) {
 							creature->onAttacking(EVENT_CREATURE_THINK_INTERVAL);
@@ -6991,15 +7007,25 @@ void Game::checkCreatures() {
 					creature->onAttacking(EVENT_CREATURE_THINK_INTERVAL);
 					creature->executeConditions(EVENT_CREATURE_THINK_INTERVAL);
 				}
-				return false;
+				// Keep entry (alive and active)
+				if (writeIndex != i) {
+					bucket[writeIndex] = std::move(bucket[i]);
+				}
+				writeIndex++;
+			} else {
+				creature->inCheckCreaturesVector = false;
 			}
-
-			creature->inCheckCreaturesVector = false;
 		}
+		// Dead/expired: don't increment writeIndex (remove entry)
+	}
 
-		return true;
-	});
+	// Shrink if too many empty slots
+	bucket.resize(writeIndex);
+	if (bucket.capacity() > 64 && bucket.size() < bucket.capacity() / 4) {
+		bucket.shrink_to_fit();
+	}
 
+	checkCreatureSizes[index] = writeIndex;
 	index = (index + 1) % EVENT_CREATURECOUNT;
 }
 


### PR DESCRIPTION
Return immediately after removing NPCs/Monsters that can't spawn to avoid continuing logic. Rework creature-check machinery: add checkCreatureSizes, reserve bucket capacity when queuing creatures to reduce reallocations, and replace std::erase_if with a manual compacting loop in checkCreatures. The new loop skips empty buckets early, schedules delayed monster attack work as before, compacts live entries in-place (writeIndex), clears inCheckCreaturesVector for removed entries, resizes/shrinks buckets heuristically, and updates tracked sizes. Changes reduce memory churn and prevent potential use-after-processing after removal.