### PR TITLE
fix: Tibia Coins cannot be offered on the market (resource 0x5B never sent)

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6135,6 +6135,14 @@ void ProtocolGame::sendCoinBalance() {
 	}
 
 	writeToOutputBuffer(msg);
+
+	// PATCH LOCAL (CoxaOT): o 0xDF acima nao alimenta o market do cliente 15.x.
+	// O t_market.lua usa getResourceBalance(91) para saber quantas coins podem
+	// ser ofertadas; sem o 0xEE a barra de quantidade fica presa em setRange(0,0).
+	if (!oldProtocol) {
+		sendResourceBalance(RESOURCE_COIN_NORMAL, player->coinBalance);
+		sendResourceBalance(RESOURCE_COIN_TRANSFERRABLE, player->coinTransferableBalance);
+	}
 }
 
 void ProtocolGame::updateCoinBalance() {

--- a/src/server/server_definitions.hpp
+++ b/src/server/server_definitions.hpp
@@ -78,7 +78,12 @@ enum Resource_t : uint8_t {
 	RESOURCE_LESSER_FRAGMENT = 0x54,
 	RESOURCE_GREATER_FRAGMENT = 0x55,
 	RESOURCE_BOUNTY_POINTS = 0x56,
-	RESOURCE_SOULSEALS_POINTS = 0x57
+	RESOURCE_SOULSEALS_POINTS = 0x57,
+	// PATCH LOCAL (CoxaOT): faltavam no upstream. O market do cliente 15.x le o
+	// saldo de coins transferiveis por AQUI (getResourceBalance(91)), nao pelo
+	// pacote 0xDF -- sem isso a barra de quantidade da oferta trava em zero.
+	RESOURCE_COIN_NORMAL = 0x5A,
+	RESOURCE_COIN_TRANSFERRABLE = 0x5B
 };
 
 enum CharmResource_t : uint8_t {


### PR DESCRIPTION
On a 15.25 client it is impossible to create a market offer for Tibia Coins. The price field accepts input, but the **amount** control stays locked at zero, with no error message.

**Cause.** `Resource_t` in `src/server/server_definitions.hpp` ends at `0x57`. The 15.x client reads how many coins may be offered from the resource balance:

```lua
-- modules/game_market/market_helpers.lua
function getTransferableTibiaCoins()
    return player:getResourceBalance(91) or 0  -- 0x5B
end
```

and then:

```lua
-- modules/game_market/t_market.lua
local itemCount = isTibiaCoin and getTransferableTibiaCoins() or getDepotItemCount(...)
if itemCount > 0 then ... else
    mainMarket.amountCreateScrollBar:setRange(0, 0)   -- locked
end
```

The server does send the balance, but only through `0xDF` (`sendCoinBalance`), which the market module does not read. Since `0x5B` never arrives, `getResourceBalance(91)` is always `0`.

This is server-side only — `Game::playerCreateMarketOffer` already handles `ITEM_STORE_COIN` correctly; the client simply never lets the request be built.

**Fix.** Add `RESOURCE_COIN_NORMAL = 0x5A` / `RESOURCE_COIN_TRANSFERRABLE = 0x5B` and emit them at the end of `sendCoinBalance()`. The client parses this resource as `u64` (default branch of `parseResourceBalance`), which is what `sendResourceBalance` already writes, so no format change is needed.

Guarded by `!oldProtocol`, so 11.00 clients are unaffected.

Reported by a player on a 15.25 OTClient build: the amount control is locked at zero while the price field works. `grep` over `Resource_t` confirms `0x5B` has no sender on the server side. I have not yet had the reporter re-test with the patch applied, so treat the fix as reasoned from both sources rather than confirmed end to end.
