### PR TITLE
fix: Apply  Wheel damage reduction multiplier to damage

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7594,6 +7594,11 @@ void Game::applyWheelOfDestinyEffectsToDamage(CombatDamage &damage, const std::s
 		damage.secondary.value += (damage.secondary.value * (damage.damageMultiplier)) / 100.;
 	}
 
+	if (damage.damageReductionMultiplier > 0) {
+		damage.primary.value -= (damage.primary.value * damage.damageReductionMultiplier) / 100;
+		damage.secondary.value -= (damage.secondary.value * damage.damageReductionMultiplier) / 100;
+	}
+
 	if (attackerPlayer) {
 		damage.primary.value -= attackerPlayer->wheel()->getStat(WheelStat_t::DAMAGE);
 		if (damage.secondary.value != 0) {


### PR DESCRIPTION
Add handling for damageReductionMultiplier in applyWheelOfDestinyEffectsToDamage: when > 0, reduce primary and secondary damage by that percentage before applying attacker wheel DAMAGE stat. Ensures damageReductionMultiplier properly decreases final damage values.