### PR TITLE
fix: Item::transform crash on invalid target id

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -3460,6 +3460,11 @@ std::shared_ptr<Item> Item::transform(uint16_t itemId, uint16_t itemCount /*= -1
 		newItem = Item::CreateItem(itemId, itemCount);
 	}
 
+	if (!newItem) {
+		g_logger().error("[{}] failed to transform item {} to {}, CreateItem returned nullptr", __FUNCTION__, getID(), itemId);
+		return nullptr;
+	}
+
 	const int32_t itemIndex = cylinder->getThingIndex(static_self_cast<Item>());
 	const auto duration = getDuration();
 	if (duration > 0) {


### PR DESCRIPTION
Add a nullptr check after CreateItem in src/items/item.cpp. If CreateItem returns nullptr, log an error with the function name and item IDs and return nullptr to avoid dereferencing a null pointer and possible crash.