### PR TITLE
fix: Use unique_ptr for Lua testInterface

### DIFF
--- a/src/lua/scripts/lua_environment.cpp
+++ b/src/lua/scripts/lua_environment.cpp
@@ -35,9 +35,6 @@ LuaEnvironment::LuaEnvironment() :
 	LuaScriptInterface("Main Interface") { }
 
 LuaEnvironment::~LuaEnvironment() {
-	if (!testInterface) {
-	}
-
 	LuaEnvironment::shuttingDown = true;
 	closeState();
 }
@@ -96,10 +93,10 @@ bool LuaEnvironment::closeState() {
 
 LuaScriptInterface* LuaEnvironment::getTestInterface() {
 	if (!testInterface) {
-		testInterface = new LuaScriptInterface("Test Interface");
+		testInterface = std::make_unique<LuaScriptInterface>("Test Interface");
 		testInterface->initState();
 	}
-	return testInterface;
+	return testInterface.get();
 }
 
 const std::unique_ptr<AreaCombat> &LuaEnvironment::getAreaObject(uint32_t id) const {

--- a/src/lua/scripts/lua_environment.hpp
+++ b/src/lua/scripts/lua_environment.hpp
@@ -70,7 +70,7 @@ private:
 	phmap::flat_hash_map<LuaScriptInterface*, std::vector<uint32_t>> areaIdMap;
 	uint32_t lastAreaId = 0;
 
-	LuaScriptInterface* testInterface = nullptr;
+	std::unique_ptr<LuaScriptInterface> testInterface;
 
 	friend class LuaScriptInterface;
 	friend class GlobalFunctions;


### PR DESCRIPTION
Convert LuaEnvironment::testInterface from a raw pointer to std::unique_ptr, construct it with std::make_unique in getTestInterface(), and return the raw pointer via get(). Remove an empty destructor check and perform a small destructor/cleanup tweak. Modernizes ownership, prevents leaks, and clarifies lifetime management.