### PR TITLE
fix: Andrew Lyze: lets player craft compass without all required items

### DIFF
--- a/data-global/npc/andrew_lyze.lua
+++ b/data-global/npc/andrew_lyze.lua
@@ -149,13 +149,12 @@ local function creatureSayCallback(npc, creature, type, message)
 		end
 	elseif MsgContains(message, "yes") then
 		if npcHandler:getTopic(playerId) == 11 then
-			local haveItens = false
+			local haveItens = true
 
 			for _, k in pairs(buildCompass) do
-				if player:getItemCount(k.id) >= k.qnt then
-					haveItens = true
-				else
+				if player:getItemCount(k.id) < k.qnt then
 					haveItens = false
+					break
 				end
 			end
 
@@ -198,13 +197,12 @@ local function creatureSayCallback(npc, creature, type, message)
 		end
 	elseif MsgContains(message, "unleash") then
 		if player:getStorageValue(Storage.Quest.U12_00.TheDreamCourts.UnsafeRelease.Questline) == 2 then
-			local haveItens = false
+			local haveItens = true
 
 			for _, k in pairs(chargeCompass) do
-				if player:getItemCount(k.id) >= k.qnt then
-					haveItens = true
-				else
+				if player:getItemCount(k.id) < k.qnt then
 					haveItens = false
+					break
 				end
 			end
 


### PR DESCRIPTION
 The 'have all items?' check loops over buildCompass reassigning haveItens = true/false every iteration without breaking, so only the LAST item examined decides the result (Lua pairs() order is unspecified). 

A player possessing only the last-iterated required item passes the gate. The removal loop (lines 163-167) removes items only if getItemCount >= qnt, silently skipping missing ones, and the reward player:addItem(chargeableCompass, 1) (line 173) plus questline progression are still granted. Same anti-pattern repeats in the 'unleash' branch at lines 203-216. Reward items are quest items, so this is a quest-skip cheat rather than an economic dupe.