### PR TITLE
fix: Remove duplicate combat effect for ice crystal bomb

### DIFF
--- a/data-global/scripts/spells/monster/ice_crystal_bomb.lua
+++ b/data-global/scripts/spells/monster/ice_crystal_bomb.lua
@@ -1,6 +1,5 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ICEDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, 44)
 combat:setParameter(COMBAT_PARAM_EFFECT, 53)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
 combat:setParameter(COMBAT_PARAM_USECHARGES, 1)


### PR DESCRIPTION
Delete the redundant setParameter(COMBAT_PARAM_EFFECT, 44) in data-global/scripts/spells/monster/ice_crystal_bomb.lua so the spell uses effect 53 only. Prevents conflicting visual effect settings and ensures the intended effect is applied.