### PR TITLE
fix(config): let rateLoot accept decimal values

### DIFF
--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -66,7 +66,7 @@ function getTitle(uid)
 end
 
 function getLootRandom(modifier)
-	local multi = (configManager.getNumber(configKeys.RATE_LOOT) * SCHEDULE_LOOT_RATE) * (modifier or 1)
+	local multi = (configManager.getFloat(configKeys.RATE_LOOT) * SCHEDULE_LOOT_RATE) * (modifier or 1)
 	return math.random(0, MAX_LOOTCHANCE) * 100 / math.max(1, multi)
 end
 

--- a/data/libs/functions/monster.lua
+++ b/data/libs/functions/monster.lua
@@ -205,7 +205,7 @@ do
 	end
 
 	function MonsterType.getBossReward(self, lootFactor, topScore, equipmentOnly, lootTable, player)
-		if configManager.getNumber(configKeys.RATE_LOOT) <= 0 then
+		if configManager.getFloat(configKeys.RATE_LOOT) <= 0 then
 			return lootTable or {}
 		end
 

--- a/data/libs/functions/monstertype.lua
+++ b/data/libs/functions/monstertype.lua
@@ -2,7 +2,7 @@
 ---@param config { factor: number, gut: boolean, filter?: fun(itemType: ItemType, unique: boolean): boolean }
 ---@return LootItems
 function MonsterType:generateLootRoll(config, resultTable, player)
-	if configManager.getNumber(configKeys.RATE_LOOT) <= 0 then
+	if configManager.getFloat(configKeys.RATE_LOOT) <= 0 then
 		return resultTable or {}
 	end
 

--- a/data/scripts/talkactions/player/server_info.lua
+++ b/data/scripts/talkactions/player/server_info.lua
@@ -28,7 +28,7 @@ function serverInfo.onSay(player, words, param)
 
 	text = text
 		.. "\nLoot rate: "
-		.. configManager.getNumber(configKeys.RATE_LOOT)
+		.. configManager.getFloat(configKeys.RATE_LOOT)
 		.. "x"
 		.. "\nSpawns rate: "
 		.. configManager.getNumber(configKeys.RATE_SPAWN)

--- a/src/config/configmanager.cpp
+++ b/src/config/configmanager.cpp
@@ -375,7 +375,9 @@ bool ConfigManager::load() {
 	loadIntConfig(L, PZ_LOCKED, "pzLocked", 60000);
 	loadIntConfig(L, RATE_EXPERIENCE, "rateExp", 1);
 	loadIntConfig(L, RATE_KILLING_IN_THE_NAME_OF_POINTS, "rateKillingInTheNameOfPoints", 1);
-	loadIntConfig(L, RATE_LOOT, "rateLoot", 1);
+	// rateLoot accepts decimals: loadIntConfig static_casts to int32_t and would
+	// silently drop the fractional part ("rateLoot = 2.5" became 2, with no warning).
+	loadFloatConfig(L, RATE_LOOT, "rateLoot", 1.0);
 	loadIntConfig(L, RATE_MAGIC, "rateMagic", 1);
 	loadIntConfig(L, RATE_SKILL, "rateSkill", 1);
 	loadIntConfig(L, RATE_SPAWN, "rateSpawn", 1);

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -2558,7 +2558,7 @@ void Monster::dropLoot(const std::shared_ptr<Container> &corpse, const std::shar
 			}
 		}
 
-		if (!this->isRewardBoss() && g_configManager().getNumber(RATE_LOOT) > 0) {
+		if (!this->isRewardBoss() && g_configManager().getFloat(RATE_LOOT) > 0) {
 			g_callbacks().executeCallback(EventCallback_t::monsterOnDropLoot, &EventCallback::monsterOnDropLoot, getMonster(), corpse);
 			g_callbacks().executeCallback(EventCallback_t::monsterPostDropLoot, &EventCallback::monsterPostDropLoot, getMonster(), corpse);
 		}

--- a/src/server/network/protocol/protocolstatus.cpp
+++ b/src/server/network/protocol/protocolstatus.cpp
@@ -142,7 +142,9 @@ void ProtocolStatus::sendStatusString() {
 	pugi::xml_node rates = tsqp.append_child("rates");
 	rates.append_attribute("experience") = std::to_string(g_configManager().getNumber(RATE_EXPERIENCE)).c_str();
 	rates.append_attribute("skill") = std::to_string(g_configManager().getNumber(RATE_SKILL)).c_str();
-	rates.append_attribute("loot") = std::to_string(g_configManager().getNumber(RATE_LOOT)).c_str();
+	// RATE_LOOT is stored as a float; getNumber() would hit the wrong type branch,
+	// return 0 and make the status protocol announce loot="0" while looting worked.
+	rates.append_attribute("loot") = fmt::format("{:g}", g_configManager().getFloat(RATE_LOOT)).c_str();
 	rates.append_attribute("magic") = std::to_string(g_configManager().getNumber(RATE_MAGIC)).c_str();
 	rates.append_attribute("spawn") = std::to_string(g_configManager().getNumber(RATE_SPAWN)).c_str();
 


### PR DESCRIPTION
`rateLoot` is loaded with `loadIntConfig`, which does `static_cast<int32_t>` and silently drops the fractional part — `rateLoot = 2.5` becomes `2`, with no warning and nothing in `config.lua` suggesting the field is integer-only.

Switching it to `loadFloatConfig` forces every reader to be updated, because `getNumber()` on a value stored as a float takes the wrong type branch: it returns `0` and logs a warning (`configmanager.cpp:529-533`). The readers are:

| file | why it matters |
|---|---|
| `src/creatures/monsters/monster.cpp` | the `> 0` gate that decides whether loot is generated at all |
| `src/server/network/protocol/protocolstatus.cpp` | easy to miss — the server kept announcing `loot="0"` while looting itself worked fine |
| `data/libs/functions/functions.lua` | `getLootRandom()`, the actual multiplier |
| `data/libs/functions/monster.lua`, `monstertype.lua` | the same `<= 0` gate on the Lua side |
| `data/scripts/talkactions/player/server_info.lua` | what `!serverinfo` shows the player |

`protocolstatus.cpp` uses `fmt::format("{:g}", ...)` so the value comes out as `2.5` rather than `2.500000`.

### Testing

Running on a live server (Crystal 15.25). With `rateLoot = 2.5` the status protocol reports `loot="2.5"` and fractional rates apply to drops; with `rateLoot = 3` behaviour is unchanged from before. The warning in the log was what exposed the missed `protocolstatus.cpp` reader in the first place.

Note for LuaJIT (5.1 semantics, as used here): a non-integer float passed where an integer is expected truncates. On Lua 5.3+ `lua_tointeger` would return 0 instead — another reason the readers must match the stored type.
