### PR TITLE
fix: Respect PZ-lock before teleport and fix nil check

### DIFF
--- a/data/npclib/npc_system/modules.lua
+++ b/data/npclib/npc_system/modules.lua
@@ -586,7 +586,9 @@ if Modules == nil then
 		local destination = Position(parameters.destination)
 
 		if player:isPremium() or not parameters.premium then
-			if player:removeMoneyBank(cost) then
+			if player:isPzLocked(player) then
+				module.npcHandler:say("Get out of there with this blood.", npc, player)
+			elseif player:removeMoneyBank(cost) then
 				local position = player:getPosition()
 				player:teleportTo(destination)
 

--- a/data/scripts/talkactions/god/add_money.lua
+++ b/data/scripts/talkactions/god/add_money.lua
@@ -30,7 +30,7 @@ function addMoney.onSay(player, words, param)
 	end
 
 	-- Check if the coins is valid
-	if amount <= 0 or amount == nil then
+	if amount == nil or amount <= 0 then
 		player:sendCancelMessage("Invalid amount.")
 		return true
 	end


### PR DESCRIPTION
Prevent bank-money teleport when a player is PZ-locked by checking isPzLocked and sending an NPC message instead of removing money/teleporting (data/npclib/npc_system/modules.lua). Also harden add_money talkaction by checking for nil before comparing amount to 0 to avoid runtime errors (data/scripts/talkactions/god/add_money.lua).