### PR TITLE
fix: Guard against null tile item list

### DIFF
--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -382,7 +382,8 @@ void Npc::onPlayerBuyItem(const std::shared_ptr<Player> &player, uint16_t itemId
 			slotsNedeed = inBackpacks ? std::ceil(static_cast<double>(amount) / shoppingBagSlots) : static_cast<double>(amount);
 		}
 
-		if ((static_cast<double>(tile->getItemList()->size()) + (slotsNedeed - player->getFreeBackpackSlots())) > 30) {
+		const TileItemVector* itemList = tile->getItemList();
+		if ((static_cast<double>(itemList ? itemList->size() : 0) + (slotsNedeed - player->getFreeBackpackSlots())) > 30) {
 			player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 			return;
 		}

--- a/src/lua/functions/creatures/npc/npc_functions.cpp
+++ b/src/lua/functions/creatures/npc/npc_functions.cpp
@@ -628,7 +628,8 @@ int NpcFunctions::luaNpcSellItem(lua_State* L) {
 			slotsNedeed = inBackpacks ? std::ceil(amount / shoppingBagSlots) : amount;
 		}
 
-		if ((static_cast<double>(tile->getItemList()->size()) + (slotsNedeed - player->getFreeBackpackSlots())) > 30) {
+		const TileItemVector* itemList = tile->getItemList();
+		if ((static_cast<double>(itemList ? itemList->size() : 0) + (slotsNedeed - player->getFreeBackpackSlots())) > 30) {
 			Lua::pushBoolean(L, false);
 			player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 			return 1;


### PR DESCRIPTION
Avoid dereferencing a null pointer returned by tile->getItemList() by storing the pointer in a local const TileItemVector* and using a conditional size (0 when null). Applied to Npc::onPlayerBuyItem and luaNpcSellItem to prevent crashes when a tile has no item list and preserve existing room-check behavior.