### PR TITLE
fix: null dereference in updateSaleShopList

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5939,8 +5939,12 @@ std::shared_ptr<Thing> Player::getThing(size_t index) const {
 
 // TODO: review this function
 bool Player::updateSaleShopList(const std::shared_ptr<Item> &item) {
+	if (!item) {
+		return true;
+	}
+
 	const uint16_t itemId = item->getID();
-	if (!itemId || !item) {
+	if (!itemId) {
 		return true;
 	}
 


### PR DESCRIPTION
Add an early null check for the item shared_ptr in Player::updateSaleShopList before calling getID(), and remove the redundant null check. Function now returns early if item is null or itemId is zero, preventing a potential dereference/crash.