### PR TITLE
fix: reclaimExcessPoints() early-returns when !canOpenWheel

### DIFF
--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -896,6 +896,17 @@ uint16_t PlayerWheel::getUnusedPoints() const {
 
 void PlayerWheel::reclaimExcessPoints() {
 	if (!canOpenWheel()) {
+		bool changed = false;
+		for (auto slot : magic_enum::enum_values<WheelSlots_t>()) {
+			if (getPointsBySlotType(slot) > 0) {
+				setPointsBySlotType(static_cast<uint8_t>(slot), 0);
+				changed = true;
+			}
+		}
+		if (changed) {
+			loadPlayerBonusData();
+			saveDBPlayerSlotPointsOnLogout();
+		}
 		return;
 	}
 


### PR DESCRIPTION
When a player cannot open the wheel, reclaimExcessPoints() now iterates all WheelSlots_t and zeroes any positive slot points. If any points were cleared it calls loadPlayerBonusData() and saveDBPlayerSlotPointsOnLogout() to update in-memory state and persist changes. This prevents stale/unauthorized slot points from remaining while the wheel is locked. reclaimExcessPoints() early-returns when !canOpenWheel, so de-level to <=50 never reclaims