### PR TITLE
fix: Safeguard bank transactions and Lua money validation

### DIFF
--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -282,7 +282,8 @@ function clearForgotten(fromPosition, toPosition, exitPosition, storage)
 end
 
 function isValidMoney(money)
-	return isNumber(money) and money > 0 and money < 4294967296
+	-- 2^53: max integer LuaJIT doubles represent exactly (bank balance is uint64_t in C++)
+	return isNumber(money) and money > 0 and money < 9007199254740992
 end
 
 function iterateArea(func, from, to)

--- a/src/game/bank/bank.cpp
+++ b/src/game/bank/bank.cpp
@@ -47,7 +47,12 @@ Bank::~Bank() {
 }
 
 bool Bank::credit(uint64_t amount) {
-	return balance(balance() + amount);
+	const uint64_t current = balance();
+	if (amount > UINT64_MAX - current) {
+		g_logger().error("Bank::credit: overflow prevented for amount {}", amount);
+		return false;
+	}
+	return balance(current + amount);
 }
 
 bool Bank::debit(uint64_t amount) {
@@ -133,7 +138,11 @@ bool Bank::transferTo(const std::shared_ptr<Bank> &destination, uint64_t amount)
 		}
 	}
 
-	if (!(debit(amount) && destination->credit(amount))) {
+	if (!debit(amount)) {
+		return false;
+	}
+	if (!destination->credit(amount)) {
+		balance(balance() + amount);
 		return false;
 	}
 
@@ -183,8 +192,12 @@ bool Bank::deposit(const std::shared_ptr<Bank> &destination, uint64_t amount) {
 	if (!g_game().removeMoney(bankable->getPlayer(), amount)) {
 		return false;
 	}
+	if (!destination->credit(amount)) {
+		g_game().addMoney(bankable->getPlayer(), amount);
+		return false;
+	}
 	if (bankable->getPlayer() != nullptr) {
 		g_metrics().addCounter("balance_decrease", amount, { { "player", bankable->getPlayer()->getName() }, { "context", "bank_deposit" } });
 	}
-	return destination->credit(amount);
+	return true;
 }


### PR DESCRIPTION
Add safety checks and refunds for bank operations and adjust Lua money validation. Bank::credit now prevents uint64 overflow and logs an error. transferTo restores the source balance if destination->credit fails. deposit refunds the player when crediting the destination fails. Update Lua isValidMoney upper bound to 2^53 (LuaJIT exact integer range) with a clarifying comment.